### PR TITLE
feat: Guard against missing `window.CSSStyleSheet`

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -492,6 +492,11 @@ function initStyleSheetObserver(
   { styleSheetRuleCb, mirror }: observerParam,
   { win }: { win: IWindow },
 ): listenerHandler {
+  if (!win.CSSStyleSheet || !win.CSSStyleSheet.prototype) {
+    // If, for whatever reason, CSSStyleSheet is not available, we skip the observation of stylesheets.
+    return () => {};
+  }
+
   const insertRule = win.CSSStyleSheet.prototype.insertRule;
   win.CSSStyleSheet.prototype.insertRule = function (
     rule: string,


### PR DESCRIPTION
This seems to just be unavailable sometimes, crashing stuff.

Upstream PR: https://github.com/rrweb-io/rrweb/pull/1088