### PR TITLE
fix: Ignore errors in style observers

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -866,8 +866,12 @@ export function initObservers(
     viewportResizeHandler();
     inputHandler();
     mediaInteractionHandler();
-    styleSheetObserver();
-    styleDeclarationObserver();
+    try {
+      styleSheetObserver();
+      styleDeclarationObserver();
+    } catch(e) {
+      // ignore errors in style observers
+    }
     fontObserver();
     pluginHandlers.forEach((h) => h());
   };


### PR DESCRIPTION
We keep getting errors from the stylesheet observer callback. So let's try catch these to be safe.