### PR TITLE
build(repo): Add `build:tarball` scripts

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,15 @@
+github:
+  owner: getsentry
+  repo: rrweb
+changelogPolicy: simple
+preReleaseCommand: bash scripts/craft-pre-release.sh
+requireNames:
+  - /^sentry-internal-rrweb-snapshot-.*\.tgz$/
+  - /^sentry-internal-rrweb-player-.*\.tgz$/
+  - /^sentry-internal-rrweb-.*\.tgz$/
+  - /^sentry-internal-rrdom-.*\.tgz$/
+targets:
+  - name: github
+    includeNames: /^sentry-.*.tgz$/
+  - name: npm
+    includeNames: /^sentry-.*.tgz$/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:watch": "yarn lerna run test:watch --parallel",
     "dev": "yarn lerna run dev --parallel",
     "repl": "cd packages/rrweb && npm run repl",
-    "postinstall": "node node_modules/puppeteer/install.js"
+    "postinstall": "node node_modules/puppeteer/install.js",
+    "build:tarball": "yarn lerna run build:tarball"
   },
   "volta": {
     "node": "12.22.12",

--- a/packages/rrdom/LICENSE
+++ b/packages/rrdom/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2023 Sentry (https://sentry.io) and individual contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -6,7 +6,8 @@
     "bundle": "rollup --config",
     "bundle:es-only": "cross-env ES_ONLY=true rollup --config",
     "test": "jest",
-    "prepublish": "npm run bundle"
+    "prepublish": "npm run bundle",
+    "build:tarball": "npm pack"
   },
   "keywords": [
     "rrweb",

--- a/packages/rrweb-player/LICENSE
+++ b/packages/rrweb-player/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2023 Sentry (https://sentry.io) and individual contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -33,7 +33,8 @@
     "prepublishOnly": "yarn build",
     "start": "sirv public",
     "validate": "svelte-check",
-    "prepublish": "yarn build"
+    "prepublish": "yarn build",
+    "build:tarball": "npm pack"
   },
   "description": "rrweb's replayer UI",
   "main": "lib/index.js",

--- a/packages/rrweb-snapshot/LICENSE
+++ b/packages/rrweb-snapshot/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2023 Sentry (https://sentry.io) and individual contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -11,7 +11,8 @@
     "bundle:es-only": "cross-env ES_ONLY=true rollup --config",
     "dev": "yarn bundle:es-only --watch",
     "typings": "tsc -d --declarationDir typings",
-    "prepublish": "npm run typings && npm run bundle"
+    "prepublish": "npm run typings && npm run bundle",
+    "build:tarball": "npm pack"
   },
   "repository": {
     "type": "git",

--- a/packages/rrweb/LICENSE
+++ b/packages/rrweb/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2023 Sentry (https://sentry.io) and individual contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -14,7 +14,8 @@
     "bundle": "rollup --config",
     "typings": "tsc -d --declarationDir typings",
     "check-types": "tsc -noEmit",
-    "prepublish": "npm run typings && npm run bundle"
+    "prepublish": "npm run typings && npm run bundle",
+    "build:tarball": "npm pack"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds npm scripts to build NPM tarballs. 
Because rrweb uses [release-it](https://github.com/release-it/release-it) for publishing their packages, there was no need to create tarballs before. However, as we're using Craft and we have to put tarballs into the GHA build artifacts for craft to pick them up, we need a script to build them easily. 

Furthermore, release-it seems to have some way of adding the `LICENSE` file to the respective packages. We actually need to copy them into the packages to have them included in the tarballs.

Due to how rrweb set up the `prepack` hook, whenever `yarn build:tarball` is executed, the other build steps (rollup, type checking) are executed automatically beforehand. While this means we're probably gonna execute builds twice in CI, I think this is fine as we're not gonna release often (🤞) and we want to keep changes diverging from upstream minimal. 

ref #15