### PR TITLE
publish(repo): Add Craft config 

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,15 @@
+github:
+  owner: getsentry
+  repo: rrweb
+changelogPolicy: simple
+preReleaseCommand: bash scripts/craft-pre-release.sh
+requireNames:
+  - /^sentry-internal-rrweb-snapshot-.*\.tgz$/
+  - /^sentry-internal-rrweb-player-.*\.tgz$/
+  - /^sentry-internal-rrweb-.*\.tgz$/
+  - /^sentry-internal-rrdom-.*\.tgz$/
+targets:
+  - name: github
+    includeNames: /^sentry-.*.tgz$/
+  - name: npm
+    includeNames: /^sentry-.*.tgz$/


### PR DESCRIPTION
This PR adds the craft config file we need to publish the rrweb packages.

