### PR TITLE
publish(ci): Add "Prepare Release" GHA and Artifacts upload

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  release:
+  job_test:
     name: Tests
     runs-on: ubuntu-latest
     steps:
@@ -26,5 +26,31 @@ jobs:
 
       - name: Run tests
         # Skip this for now, as it somehow always fails
-        if: 1 == 2 
+        if: 1 == 2
         run: xvfb-run --server-args="-screen 0 1920x1080x24" yarn test
+
+  job_artifacts:
+    needs: job_test
+    name: Upload Artifacts
+    runs-on: ubuntu-latest
+    # Build artifacts are only needed for releasing workflow.
+    if: startsWith(github.ref, 'refs/heads/release/')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: volta-cli/action@v3
+
+      - name: Install Dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build Tarballs
+        run: yarn build:tarball
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.sha }}
+          path: |
+            ${{ github.workspace }}/packages/**/*.tgz

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,11 @@
-name: Tests
+name: Build & Tests
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+      - release/**
+  pull_request:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Prepare Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: false
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,12 @@ on:
         description: Force a release even when there are release-blockers (optional)
         required: false
       merge_target:
-        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        description: Target branch to merge into. Uses the default branch, sentry-v1, as a fallback (optional)
         required: false
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: "Release a new version"
+    name: 'Release a new version'
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR prepares our CI for publishing our packages by 

* adding the "Prepare Release" Github Action (analogously to sentry-javascript or sentry-bundler-plugins)
* uploading build artifacts  to GH which craft pulls when publishing

Draft until #21 and #22 are merged

ref #15