### PR TITLE
build(repo): Add craft pre-release script

### DIFF
--- a/scripts/craft-pre-release.sh
+++ b/scripts/craft-pre-release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -eux
+
+# Move to the project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd $SCRIPT_DIR/..
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+# Do not tag and commit changes made by "npm version"
+export npm_config_git_tag_version=false
+
+yarn install --frozen-lockfile
+# --force-publish - force publish all packages, this will skip the lerna changed check for changed packages and forces a package that didn't have a git diff change to be updated.
+# --exact - specify updated dependencies in updated packages exactly (with no punctuation), instead of as semver compatible (with a ^).
+# --no-git-tag-version - don't commit changes to package.json files and don't tag the release.
+# --no-push - don't push committed and tagged changes.
+# --include-merged-tags - include tags from merged branches when detecting changed packages.
+# --yes - skip all confirmation prompts
+yarn lerna version --force-publish --exact --no-git-tag-version --no-push --include-merged-tags --yes "${NEW_VERSION}"


### PR DESCRIPTION
This PR adds a pre-release script that craft executes to set the version of the rrweb packages.

A note on version bumps:

rrweb uses different versions for every package. Since we don't do this in any of our Sentry monorepos, we're going to align the versions of all packages, bumping them to v1.100.0 for the first release. This is the easiest way forward and we're not breaking anything by aligning the versions. 

ref #15