### PR TITLE
chore(rrweb): Add `publishConfig` field to package.jsons

### DIFF
--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -9,6 +9,9 @@
     "prepublish": "npm run bundle",
     "build:tarball": "npm pack"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "rrweb",
     "rrdom"

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@sentry-internal/rrweb-player",
   "version": "0.7.14",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.0",
     "@rollup/plugin-node-resolve": "^7.0.0",

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -2,6 +2,9 @@
   "name": "@sentry-internal/rrweb-snapshot",
   "version": "1.1.14",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prepare": "npm run prepack",
     "prepack": "npm run bundle && npm run typings",

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -2,6 +2,9 @@
   "name": "@sentry-internal/rrweb",
   "version": "1.1.3",
   "description": "record and replay the web",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prepare": "npm run prepack",
     "prepack": "npm run bundle",


### PR DESCRIPTION
For the four rrweb packages, the `publishConfig` field in their `package.json`s was missing. This PR adds it with a public config so we can avoid NPM publish throwing an error that these packages are private.