### PR TITLE
fix: Handle case where `event` is null/undefined

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -73,10 +73,9 @@ function getEventTarget(event: Event | NonStandardEvent): EventTarget | null {
     } else if ('path' in event && event.path.length) {
       return event.path[0];
     }
-    return event.target;
-  } catch {
-    return event.target;
-  }
+  } catch {}
+
+  return event && event.target;
 }
 
 export function initMutationObserver(
@@ -876,7 +875,7 @@ export function initObservers(
     try {
       styleSheetObserver();
       styleDeclarationObserver();
-    } catch(e) {
+    } catch (e) {
       // ignore errors in style observers
     }
     fontObserver();


### PR DESCRIPTION
We got one or two bugs that failed due to `event` not being defined.