### PR TITLE
fix: Catch style mutation handling

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -533,7 +533,7 @@ export default class MutationBuffer {
             }
           } catch (error) {
             console.warn(
-              'Error when parsing update to style attribute:',
+              '[rrweb] Error when parsing update to style attribute:',
               error,
             );
           }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -509,26 +509,33 @@ export default class MutationBuffer {
           ) {
             item.attributes.style = {};
           }
-          const styleObj = item.attributes.style as styleAttributeValue;
-          for (const pname of Array.from(target.style)) {
-            const newValue = target.style.getPropertyValue(pname);
-            const newPriority = target.style.getPropertyPriority(pname);
-            if (
-              newValue !== old.style.getPropertyValue(pname) ||
-              newPriority !== old.style.getPropertyPriority(pname)
-            ) {
-              if (newPriority === '') {
-                styleObj[pname] = newValue;
-              } else {
-                styleObj[pname] = [newValue, newPriority];
+          try {
+            const styleObj = item.attributes.style as styleAttributeValue;
+            for (const pname of Array.from(target.style)) {
+              const newValue = target.style.getPropertyValue(pname);
+              const newPriority = target.style.getPropertyPriority(pname);
+              if (
+                newValue !== old.style.getPropertyValue(pname) ||
+                newPriority !== old.style.getPropertyPriority(pname)
+              ) {
+                if (newPriority === '') {
+                  styleObj[pname] = newValue;
+                } else {
+                  styleObj[pname] = [newValue, newPriority];
+                }
               }
             }
-          }
-          for (const pname of Array.from(old.style)) {
-            if (target.style.getPropertyValue(pname) === '') {
-              // "if not set, returns the empty string"
-              styleObj[pname] = false; // delete
+            for (const pname of Array.from(old.style)) {
+              if (target.style.getPropertyValue(pname) === '') {
+                // "if not set, returns the empty string"
+                styleObj[pname] = false; // delete
+              }
             }
+          } catch (error) {
+            console.warn(
+              'Error when parsing update to style attribute:',
+              error,
+            );
           }
         } else {
           // overwrite attribute if the mutations was triggered in same time


### PR DESCRIPTION
We got some bugs where `target.style` was undefined, so just try-catching all of this.