### PR TITLE
fix: Fix accidential `dependencies` of `rrweb-snapshot`

### DIFF
--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -51,6 +51,7 @@
     "@types/puppeteer": "^7.0.4",
     "cross-env": "^5.2.0",
     "jest": "^29.4.1",
+    "jest-environment-jsdom": "^29.4.1",
     "jest-snapshot": "^29.4.1",
     "jsdom": "^21.1.0",
     "puppeteer": "^19.6.2",
@@ -61,8 +62,5 @@
     "tslib": "^2.5.0",
     "tslint": "^4.5.1",
     "typescript": "^4.9.5"
-  },
-  "dependencies": {
-    "jest-environment-jsdom": "^29.4.1"
   }
 }


### PR DESCRIPTION
`jest-environment-jsdom` should be in `devDependencies`.