### PR TITLE
fix: Ensure we do not check `window` in module scope

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -54,35 +54,6 @@ type WindowWithAngularZone = IWindow & {
 
 export const mutationBuffers: MutationBuffer[] = [];
 
-function isCSSStyleSheetMonkeyPatchable(
-  prop:
-    | 'CSSGroupingRule'
-    | 'CSSMediaRule'
-    | 'CSSSupportsRule'
-    | 'CSSConditionRule',
-): boolean {
-  return Boolean(
-    typeof window[prop] !== 'undefined' &&
-      // Note: Generally, this check _shouldn't_ be necessary
-      // However, in some scenarios (e.g. jsdom) this can sometimes fail, so we check for it here
-      window[prop].prototype &&
-      // @ts-ignore ensure it is actually set
-      window[prop].prototype.insertRule &&
-      window[prop].prototype.deleteRule
-  );
-}
-
-const isCSSGroupingRuleSupported = isCSSStyleSheetMonkeyPatchable(
-  'CSSGroupingRule',
-);
-const isCSSMediaRuleSupported = isCSSStyleSheetMonkeyPatchable('CSSMediaRule');
-const isCSSSupportsRuleSupported = isCSSStyleSheetMonkeyPatchable(
-  'CSSSupportsRule',
-);
-const isCSSConditionRuleSupported = isCSSStyleSheetMonkeyPatchable(
-  'CSSConditionRule',
-);
-
 // Event.path is non-standard and used in some older browsers
 type NonStandardEvent = Omit<Event, 'composedPath'> & {
   path: EventTarget[];
@@ -505,13 +476,13 @@ function getNestedCSSRulePositions(rule: CSSRule): number[] {
   const positions: number[] = [];
   function recurse(childRule: CSSRule, pos: number[]) {
     if (
-      (isCSSGroupingRuleSupported &&
+      (hasNestedCSSRule('CSSGroupingRule') &&
         childRule.parentRule instanceof CSSGroupingRule) ||
-      (isCSSMediaRuleSupported &&
+      (hasNestedCSSRule('CSSMediaRule') &&
         childRule.parentRule instanceof CSSMediaRule) ||
-      (isCSSSupportsRuleSupported &&
+      (hasNestedCSSRule('CSSSupportsRule') &&
         childRule.parentRule instanceof CSSSupportsRule) ||
-      (isCSSConditionRuleSupported &&
+      (hasNestedCSSRule('CSSConditionRule') &&
         childRule.parentRule instanceof CSSConditionRule)
     ) {
       const rules = Array.from(
@@ -581,20 +552,20 @@ function initStyleSheetObserver(
   const supportedNestedCSSRuleTypes: {
     [key: string]: GroupingCSSRuleTypes;
   } = {};
-  if (isCSSGroupingRuleSupported) {
+  if (canMonkeyPatchNestedCSSRule('CSSGroupingRule')) {
     supportedNestedCSSRuleTypes.CSSGroupingRule = win.CSSGroupingRule;
   } else {
     // Some browsers (Safari) don't support CSSGroupingRule
     // https://caniuse.com/?search=cssgroupingrule
     // fall back to monkey patching classes that would have inherited from CSSGroupingRule
 
-    if (isCSSMediaRuleSupported) {
+    if (canMonkeyPatchNestedCSSRule('CSSMediaRule')) {
       supportedNestedCSSRuleTypes.CSSMediaRule = win.CSSMediaRule;
     }
-    if (isCSSConditionRuleSupported) {
+    if (canMonkeyPatchNestedCSSRule('CSSConditionRule')) {
       supportedNestedCSSRuleTypes.CSSConditionRule = win.CSSConditionRule;
     }
-    if (isCSSSupportsRuleSupported) {
+    if (canMonkeyPatchNestedCSSRule('CSSSupportsRule')) {
       supportedNestedCSSRuleTypes.CSSSupportsRule = win.CSSSupportsRule;
     }
   }
@@ -969,4 +940,25 @@ export function initObservers(
     fontObserver();
     pluginHandlers.forEach((h) => h());
   });
+}
+
+type CSSGroupingProp =
+  | 'CSSGroupingRule'
+  | 'CSSMediaRule'
+  | 'CSSSupportsRule'
+  | 'CSSConditionRule';
+
+function hasNestedCSSRule(prop: CSSGroupingProp): boolean {
+  return typeof window[prop] !== 'undefined';
+}
+
+function canMonkeyPatchNestedCSSRule(prop: CSSGroupingProp): boolean {
+  return Boolean(
+    typeof window[prop] !== 'undefined' &&
+      // Note: Generally, this check _shouldn't_ be necessary
+      // However, in some scenarios (e.g. jsdom) this can sometimes fail, so we check for it here
+      window[prop].prototype &&
+      'insertRule' in window[prop].prototype &&
+      'deleteRule' in window[prop].prototype,
+  );
 }


### PR DESCRIPTION
It appears the new check fails on node, even when not importing rrweb. I guess it may be because in development it is not treeshaken, and module scope is still evaluated.

Now, we check this every time. This may be slightly more expensive, but also safer as we'd catch it if this is removed/overwritten later on.