### PR TITLE
fix: more robust `rootShadowHost` check

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -282,7 +282,7 @@ export default class MutationBuffer {
       // ensure shadowHost is a Node, or doc.contains will throw an error
       const notInDoc =
         !this.doc.contains(n) &&
-        (rootShadowHost === null || !this.doc.contains(rootShadowHost));
+        (!rootShadowHost || !this.doc.contains(rootShadowHost));
       if (!n.parentNode || notInDoc) {
         return;
       }


### PR DESCRIPTION
This _may_ be the underlying cause [here](https://sentry.sentry.io/issues/3725692470/?project=11276&referrer=assigned_activity-email), maybe an e.g. `undefined` sneaked in there somehow. IMHO this should also safe some bytes.