### PR TITLE
fix: Exclude `modulepreload` as well

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -198,7 +198,7 @@ function buildNode(
               continue;
             } else if (
               tagName === 'link' &&
-              n.attributes.rel === 'preload' &&
+              (n.attributes.rel === 'preload' || n.attributes.rel === 'modulepreload') &&
               n.attributes.as === 'script'
             ) {
               // ignore

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -789,9 +789,9 @@ function slimDOMExcluded(
       slimDOMOptions.script &&
       // script tag
       (sn.tagName === 'script' ||
-        // preload link
+        // (module)preload link
         (sn.tagName === 'link' &&
-          sn.attributes.rel === 'preload' &&
+          (sn.attributes.rel === 'preload' || sn.attributes.rel === 'modulepreload') &&
           sn.attributes.as === 'script') ||
         // prefetch link
         (sn.tagName === 'link' &&

--- a/packages/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb-snapshot/test/__snapshots__/integration.test.ts.snap
@@ -337,6 +337,7 @@ exports[`integration tests [html file]: preload.html 1`] = `
     <title>Document</title>
     <link />
     <link />
+    <link />
   </head>
   <body></body></html>"
 `;

--- a/packages/rrweb-snapshot/test/html/preload.html
+++ b/packages/rrweb-snapshot/test/html/preload.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
+    <link rel="modulepreload" href="https://example/path/to/preload.js" as="script" />
     <link rel="preload" href="https://example/path/to/preload.js" as="script" />
     <link rel="prefetch" href="https://example/path/to/prefetch.js" />
   </head>


### PR DESCRIPTION
We were only excluding `<link rel="preload" as="script" />` but we should include `rel="modulepreload"` as well
