### PR TITLE
feat: Use JS to disable clicks in Replayer

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -411,13 +411,11 @@ export class Replayer {
 
   public enableInteract() {
     this.iframe.setAttribute('scrolling', 'auto');
-    this.iframe.style.pointerEvents = 'auto';
     this.iframe.contentDocument?.removeEventListener('click', this.handleClick);
   }
 
   public disableInteract() {
     this.iframe.setAttribute('scrolling', 'no');
-    this.iframe.style.pointerEvents = 'none';
     // Disable clicks in the iframe
     // NOTE: The previous method for this was pointer-events but that hinders
     // users from being able to use browser's "Inspect" functionality

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -273,6 +273,7 @@ export class Replayer {
         this.iframe.contentWindow && this.iframe.contentWindow.scrollTo(
           (firstFullsnapshot as fullSnapshotEvent).data.initialOffset,
         );
+        this.disableInteract();
       }, 1);
     }
     if (this.service.state.context.events.find(indicatesTouchDevice)) {
@@ -412,11 +413,16 @@ export class Replayer {
   public enableInteract() {
     this.iframe.setAttribute('scrolling', 'auto');
     this.iframe.style.pointerEvents = 'auto';
+    this.iframe.contentDocument?.removeEventListener('click', this.handleClick);
   }
 
   public disableInteract() {
     this.iframe.setAttribute('scrolling', 'no');
     this.iframe.style.pointerEvents = 'none';
+    // Disable clicks in the iframe
+    // NOTE: The previous method for this was pointer-events but that hinders
+    // users from being able to use browser's "Inspect" functionality
+    this.iframe.contentDocument?.addEventListener('click', this.handleClick);
   }
 
   /**
@@ -451,7 +457,6 @@ export class Replayer {
     // hide iframe before first meta event
     this.iframe.style.display = 'none';
     this.iframe.setAttribute('sandbox', attributes.join(' '));
-    this.disableInteract();
     this.wrapper.appendChild(this.iframe);
     if (this.iframe.contentWindow && this.iframe.contentDocument) {
       smoothscrollPolyfill(
@@ -461,6 +466,11 @@ export class Replayer {
 
       polyfill(this.iframe.contentWindow as IWindow);
     }
+  }
+
+  private handleClick(e: MouseEvent) {
+    e.preventDefault();
+    return false;
   }
 
   private handleResize(dimension: viewportResizeDimension) {

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -273,7 +273,6 @@ export class Replayer {
         this.iframe.contentWindow && this.iframe.contentWindow.scrollTo(
           (firstFullsnapshot as fullSnapshotEvent).data.initialOffset,
         );
-        this.disableInteract();
       }, 1);
     }
     if (this.service.state.context.events.find(indicatesTouchDevice)) {
@@ -694,6 +693,7 @@ export class Replayer {
     if (this.config.UNSAFE_replayCanvas) {
       this.preloadAllImages();
     }
+    this.disableInteract();
   }
 
   private insertStyleRules(

--- a/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
@@ -158,8 +158,8 @@ exports[`replayer replays same timestamp events in correct order (with addAction
         sandbox="allow-same-origin"
         width="1000"
         height="800"
-        style="display: inherit"
         scrolling="no"
+        style="display: inherit"
       ></iframe>
     </div>
   </body>

--- a/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
@@ -158,8 +158,8 @@ exports[`replayer replays same timestamp events in correct order (with addAction
         sandbox="allow-same-origin"
         width="1000"
         height="800"
-        scrolling="no"
         style="display: inherit"
+        scrolling="no"
       ></iframe>
     </div>
   </body>

--- a/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
@@ -20,7 +20,7 @@ exports[`replayer can fast forward past StyleSheetRule changes on virtual elemen
         width="1000"
         height="800"
         scrolling="no"
-        style="display: inherit; pointer-events: none"
+        style="display: inherit"
       ></iframe>
     </div>
   </body>
@@ -111,7 +111,7 @@ exports[`replayer can handle removing style elements 1`] = `
         width="1000"
         height="800"
         scrolling="no"
-        style="display: inherit; pointer-events: none"
+        style="display: inherit"
       ></iframe>
     </div>
   </body>
@@ -159,7 +159,7 @@ exports[`replayer replays same timestamp events in correct order (with addAction
         width="1000"
         height="800"
         scrolling="no"
-        style="display: inherit; pointer-events: none"
+        style="display: inherit"
       ></iframe>
     </div>
   </body>
@@ -210,7 +210,7 @@ exports[`replayer replays same timestamp events in correct order 1`] = `
         width="1000"
         height="800"
         scrolling="no"
-        style="display: inherit; pointer-events: none"
+        style="display: inherit"
       ></iframe>
     </div>
   </body>

--- a/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
@@ -17,9 +17,9 @@ exports[`replayer can fast forward past StyleSheetRule changes on virtual elemen
       ></canvas
       ><iframe
         sandbox="allow-same-origin"
-        scrolling="no"
         width="1000"
         height="800"
+        scrolling="no"
         style="display: inherit; pointer-events: none"
       ></iframe>
     </div>
@@ -108,9 +108,9 @@ exports[`replayer can handle removing style elements 1`] = `
       ></canvas
       ><iframe
         sandbox="allow-same-origin"
-        scrolling="no"
         width="1000"
         height="800"
+        scrolling="no"
         style="display: inherit; pointer-events: none"
       ></iframe>
     </div>
@@ -156,9 +156,9 @@ exports[`replayer replays same timestamp events in correct order (with addAction
       ></canvas
       ><iframe
         sandbox="allow-same-origin"
-        scrolling="no"
         width="1000"
         height="800"
+        scrolling="no"
         style="display: inherit; pointer-events: none"
       ></iframe>
     </div>
@@ -207,9 +207,9 @@ exports[`replayer replays same timestamp events in correct order 1`] = `
       ></canvas
       ><iframe
         sandbox="allow-same-origin"
-        scrolling="no"
         width="1000"
         height="800"
+        scrolling="no"
         style="display: inherit; pointer-events: none"
       ></iframe>
     </div>

--- a/packages/rrweb/typings/replay/index.d.ts
+++ b/packages/rrweb/typings/replay/index.d.ts
@@ -43,6 +43,7 @@ export declare class Replayer {
     disableInteract(): void;
     resetCache(): void;
     private setupDom;
+    private handleClick;
     private handleResize;
     private applyEventsSynchronously;
     private getCastFn;


### PR DESCRIPTION
We turned `pointer-events` on in our client so that our users can use browser tools to "inspect" the dom. Without `pointer-events`, users hovering over elements in the replay would not reflect in the dev tools.

A side-effect of enabling `pointer-events` was that users would be able to click links in the Replay and end up breaking everything. e.g. "Looks like your Replayer was destroyed"
 