### PR TITLE
fix: First record is checkout

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -492,7 +492,7 @@ function record<T = eventWithTime>(
     });
 
     const init = () => {
-      takeFullSnapshot();
+      takeFullSnapshot(true);
       handlers.push(observe(document));
     };
     if (


### PR DESCRIPTION
In order to streamline our checkout check, it makes much more sense IMHO that the first emit is considered a checkout.