### PR TITLE
feat: Remove `autoplay` attribute from audio/video tags

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -500,7 +500,9 @@ function serializeNode(
       const tagName = getValidTagName(n as HTMLElement);
       let attributes: attributes = {};
       for (const { name, value } of Array.from((n as HTMLElement).attributes)) {
-        attributes[name] = transformAttribute(doc, tagName, name, value, maskAllText, maskTextFn);
+        if (!skipAttribute(tagName, name, value)) {
+          attributes[name] = transformAttribute(doc, tagName, name, value, maskAllText, maskTextFn);
+        }
       }
       // remote css
       if (tagName === 'link' && inlineStylesheet) {
@@ -1243,3 +1245,8 @@ export function cleanupSnapshot() {
 }
 
 export default snapshot;
+
+/** We want to skip `autoplay` attribute, as this has weird results when replaying.  */
+function skipAttribute(tagName: string, attributeName: string, value?: unknown) {
+  return (tagName === 'video' || tagName === 'audio') && attributeName === 'autoplay';
+}

--- a/packages/rrweb-snapshot/test/html/video.html
+++ b/packages/rrweb-snapshot/test/html/video.html
@@ -7,7 +7,7 @@
     <title>video</title>
   </head>
   <body>
-    <video controls>
+    <video controls autoplay>
       <source src=http://techslides.com/demos/sample-videos/small.webm
       type=video/webm> <source
       src=http://techslides.com/demos/sample-videos/small.ogv type=video/ogg>


### PR DESCRIPTION
These can lead to weird results when replaying this later, so we just want to omit these.

ref: https://github.com/getsentry/sentry-javascript/issues/6602#issuecomment-1438801706