### PR TITLE
fix(build/CI): Run prepublish scripts before building tarballs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install Dependencies
         run: yarn --frozen-lockfile
 
+      - name: Build Project
+        run: yarn lerna run prepublish
+
       - name: Build Tarballs
         run: yarn build:tarball
 

--- a/packages/rrweb/typings/index.d.ts
+++ b/packages/rrweb/typings/index.d.ts
@@ -2,7 +2,7 @@ import record from './record';
 import { Replayer } from './replay';
 import { _mirror } from './utils';
 import * as utils from './utils';
-export { EventType, IncrementalSource, MouseInteractions, ReplayerEvents, } from './types';
+export * from './types';
 declare const addCustomEvent: <T>(tag: string, payload: T) => void;
 declare const freezePage: () => void;
 export { record, addCustomEvent, freezePage, Replayer, _mirror as mirror, utils, };


### PR DESCRIPTION
Previously, in the "Upload Artifacts" job, we didn't explicitly run a build command but instead relied on the package-specific `prepack` yarn scripts. This caused an incomplete `@sentry-internal/rrweb-player` package, as this package didn't have a `prepack` script. This PR now adds a step to the CI job to actually run the `prepublish` build command before packing the tarballs. 

I checked the resulting tarball against the actual rrweb player and it seems all files are present now. Uploaded artifacts of a test branch: https://github.com/getsentry/rrweb/actions/runs/4263220937

Misc: This PR also updates a type declaration file that was stale beforehand. 

closes #63 