### PR TITLE
feat(replay): Check for node existance in mirror before appending

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1406,6 +1406,12 @@ export class Replayer {
         return queue.push(mutation);
       }
 
+      // TODO(sentry): We are seeing duplicated node ids in our recording
+      // Handling this in the replayer while we look for root cause in recorder
+      if (this.mirror.getNode(mutation.node.id)) {
+        return;
+      }
+
       let parentInDocument = null;
       if (this.iframe.contentDocument.contains) {
         parentInDocument = this.iframe.contentDocument.contains(parent);


### PR DESCRIPTION
For some reason we have some recordings that have duplicated node ids. Not sure how widespread this is, but lets check for dupes before appending a mutation.
