### PR TITLE
fix: Fix CSS rules captured in Safari

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -69,6 +69,7 @@ function getCssRuleString(rule: CSSRule): string {
     }
   }
 
+  return cssStringified;
   return validateStringifiedCssRule(cssStringified);
 }
 
@@ -90,7 +91,7 @@ function isCSSImportRule(rule: CSSRule): rule is CSSImportRule {
 function stringifyStyleSheet(sheet: CSSStyleSheet): string {
   return sheet.cssRules
     ? Array.from(sheet.cssRules)
-        .map((rule) => rule.cssText || '')
+        .map((rule) => rule.cssText ? validateStringifiedCssRule(rule.cssText) : '')
         .join('')
     : '';
 }

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -69,7 +69,6 @@ function getCssRuleString(rule: CSSRule): string {
     }
   }
 
-  return cssStringified;
   return validateStringifiedCssRule(cssStringified);
 }
 

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -68,6 +68,18 @@ function getCssRuleString(rule: CSSRule): string {
       // ignore
     }
   }
+
+  return validateStringifiedCssRule(cssStringified);
+}
+
+export function validateStringifiedCssRule(cssStringified: string): string {
+  // Safari does not escape selectors with : properly
+  if (cssStringified.indexOf(':') > -1) {
+    // Replace e.g. [aa:bb] with [aa\\:bb]
+    const regex = /(\[(?:.*)[^\\])(:(?:.*)\])/gm;
+    return cssStringified.replace(regex, '$1\\$2');
+  }
+
   return cssStringified;
 }
 

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -76,7 +76,7 @@ export function validateStringifiedCssRule(cssStringified: string): string {
   // Safari does not escape selectors with : properly
   if (cssStringified.indexOf(':') > -1) {
     // Replace e.g. [aa:bb] with [aa\\:bb]
-    const regex = /(\[(?:.*)[^\\])(:(?:.*)\])/gm;
+    const regex = /(\[(?:[\w-]+)[^\\])(:(?:[\w-]+)\])/gm;
     return cssStringified.replace(regex, '$1\\$2');
   }
 

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -1,4 +1,5 @@
 import { parse, Rule, Media } from '../src/css';
+import {validateStringifiedCssRule} from './../src/snapshot';
 
 describe('css parser', () => {
   it('should save the filename and source', () => {
@@ -106,4 +107,15 @@ describe('css parser', () => {
     decl = rule.declarations![0];
     expect(decl.parent).toEqual(rule);
   });
+
+  it('parses : in attribute selectors correctly', () => {
+    const out1 = validateStringifiedCssRule('[data-foo] { color: red; }');
+    expect(out1).toEqual('[data-foo] { color: red; }');
+
+    const out2 = validateStringifiedCssRule('[data-foo:other] { color: red; }');
+    expect(out2).toEqual('[data-foo\\:other] { color: red; }');
+
+    const out3 = validateStringifiedCssRule('[data-aa\\:other] { color: red; }');
+    expect(out3).toEqual('[data-aa\\:other] { color: red; }');
+  })
 });

--- a/packages/rrweb-snapshot/typings/snapshot.d.ts
+++ b/packages/rrweb-snapshot/typings/snapshot.d.ts
@@ -1,5 +1,6 @@
 import { serializedNodeWithId, INode, idNodeMap, MaskInputOptions, SlimDOMOptions, DataURLOptions, MaskTextFn, MaskInputFn, KeepIframeSrcFn } from './types';
 export declare const IGNORED_NODE = -2;
+export declare function validateStringifiedCssRule(cssStringified: string): string;
 export declare function absoluteToStylesheet(cssText: string | null, href: string): string;
 export declare function absoluteToDoc(doc: Document, attributeValue: string): string;
 export declare function transformAttribute(doc: Document, element: HTMLElement, _tagName: string, _name: string, value: string | null, maskAllText: boolean, unmaskTextSelector: string | undefined | null, maskTextFn: MaskTextFn | undefined): string | null;


### PR DESCRIPTION
Safari does not escape `:` in attribute selectors correctly, so we need to do that instead.

See https://github.com/rrweb-io/rrweb/issues/1208

ref https://github.com/getsentry/sentry-javascript/issues/7703