### PR TITLE
fix: iframe.contentDocument / html undefined

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -682,8 +682,8 @@ export class Replayer {
     this.insertStyleRules(documentElement, head);
     if (!this.service.state.matches('playing')) {
       this.iframe.contentDocument
-        .getElementsByTagName('html')[0]
-        .classList.add('rrweb-paused');
+        ?.getElementsByTagName('html')[0]
+        ?.classList.add('rrweb-paused');
     }
     this.emitter.emit(ReplayerEvents.FullsnapshotRebuilded, event);
     if (!isSync) {


### PR DESCRIPTION
We have optional chaining checks on this in other places, must have missed one.
