### PR TITLE
fix: Fix checking for `patchTarget` in `initAdoptedStyleSheetObserver`

### DIFF
--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -957,10 +957,10 @@ export function initAdoptedStyleSheetObserver(
     host.nodeName === '#document'
       ? (host as Document).defaultView?.Document
       : host.ownerDocument?.defaultView?.ShadowRoot;
-  const originalPropertyDescriptor = Object.getOwnPropertyDescriptor(
+  const originalPropertyDescriptor = patchTarget?.prototype ? Object.getOwnPropertyDescriptor(
     patchTarget?.prototype,
     'adoptedStyleSheets',
-  );
+  ) : undefined;
   if (
     hostId === null ||
     hostId === -1 ||

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -957,10 +957,12 @@ export function initAdoptedStyleSheetObserver(
     host.nodeName === '#document'
       ? (host as Document).defaultView?.Document
       : host.ownerDocument?.defaultView?.ShadowRoot;
-  const originalPropertyDescriptor = patchTarget?.prototype ? Object.getOwnPropertyDescriptor(
-    patchTarget?.prototype,
-    'adoptedStyleSheets',
-  ) : undefined;
+  const originalPropertyDescriptor = patchTarget?.prototype
+    ? Object.getOwnPropertyDescriptor(
+        patchTarget?.prototype,
+        'adoptedStyleSheets',
+      )
+    : undefined;
   if (
     hostId === null ||
     hostId === -1 ||


### PR DESCRIPTION
Calling `Object.getOwnPropertyDescriptor(undefined, 'xx')` actually errors out, so let's probably guard there.