### PR TITLE
feat(record): Allow `callbackWrapper` to attach a `__source__` property to exceptions

### DIFF
--- a/packages/rrweb/src/record/error-handler.ts
+++ b/packages/rrweb/src/record/error-handler.ts
@@ -15,7 +15,10 @@ export function unregisterErrorHandler() {
 /**
  * Wrap callbacks in a wrapper that allows to pass errors to a configured `errorHandler` method.
  */
-export const callbackWrapper = <T extends Callback>(cb: T, errorSource?: string): T => {
+export const callbackWrapper = <T extends Callback>(
+  cb: T,
+  errorSource?: string,
+): T => {
   if (!errorHandler) {
     return cb;
   }

--- a/packages/rrweb/src/record/error-handler.ts
+++ b/packages/rrweb/src/record/error-handler.ts
@@ -15,7 +15,7 @@ export function unregisterErrorHandler() {
 /**
  * Wrap callbacks in a wrapper that allows to pass errors to a configured `errorHandler` method.
  */
-export const callbackWrapper = <T extends Callback>(cb: T): T => {
+export const callbackWrapper = <T extends Callback>(cb: T, errorSource?: string): T => {
   if (!errorHandler) {
     return cb;
   }
@@ -24,6 +24,13 @@ export const callbackWrapper = <T extends Callback>(cb: T): T => {
     try {
       return cb(...rest);
     } catch (error) {
+      // Some libraries (styled-components) rely on an exception to be thrown.
+      // Attach an optional property here to allow `errorHandler` to make
+      // additional decisions (e.g. to re-throw).
+      if (errorSource) {
+        error.__source__ = errorSource;
+      }
+
       if (errorHandler && errorHandler(error) === true) {
         return () => {
           // This will get called by `record()`'s cleanup function

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -724,6 +724,7 @@ function initStyleSheetObserver(
         }
         return target.apply(thisArg, argumentsList);
       },
+      'CSSStyleSheet.insertRule',
     ),
   });
 
@@ -891,6 +892,7 @@ function initStyleSheetObserver(
             }
             return target.apply(thisArg, argumentsList);
           },
+          'CSSStyleSheet.insertRule',
         ),
       },
     );


### PR DESCRIPTION
Allow `callbackWrapper` to attach an optional `__source__` property to a caught exception. This will allow downstream errorHandlers to decide to re-throw an exception based on the source type.


Needed to address https://github.com/getsentry/sentry-javascript/issues/9170