### PR TITLE
feat: Refactor module scope vars & export `mirror` & `takeFullSnapshot` directly

### DIFF
--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -1,6 +1,5 @@
 import record from './record';
 import { Replayer } from './replay';
-import { _mirror } from './utils';
 import * as utils from './utils';
 
 export {
@@ -27,6 +26,7 @@ export {
   addCustomEvent,
   freezePage,
   Replayer,
-  _mirror as mirror,
   utils,
 };
+
+export { takeFullSnapshot, mirror } from './record';

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -18,9 +18,6 @@ export type {
 
 export type { recordOptions } from './types';
 
-const { addCustomEvent } = record;
-const { freezePage } = record;
+export { record, Replayer, utils };
 
-export { record, addCustomEvent, freezePage, Replayer, utils };
-
-export { takeFullSnapshot, mirror } from './record';
+export { takeFullSnapshot, mirror, freezePage, addCustomEvent } from './record';

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -21,12 +21,6 @@ export type { recordOptions } from './types';
 const { addCustomEvent } = record;
 const { freezePage } = record;
 
-export {
-  record,
-  addCustomEvent,
-  freezePage,
-  Replayer,
-  utils,
-};
+export { record, addCustomEvent, freezePage, Replayer, utils };
 
 export { takeFullSnapshot, mirror } from './record';

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -67,11 +67,11 @@ declare global {
 
 let wrappedEmit!: (e: eventWithTime, isCheckout?: boolean) => void;
 
-let takeFullSnapshot!: (isCheckout?: boolean) => void;
+let _takeFullSnapshot!: (isCheckout?: boolean) => void;
 let canvasManager: CanvasManagerInterface;
 let recording = false;
 
-const mirror = createMirror();
+export const mirror = createMirror();
 function record<T = eventWithTime>(
   options: recordOptions<T> = {},
 ): listenerHandler | undefined {
@@ -256,7 +256,7 @@ function record<T = eventWithTime>(
         checkoutEveryNms &&
         e.timestamp - lastFullSnapshotEvent.timestamp > checkoutEveryNms;
       if (exceedCount || exceedTime) {
-        takeFullSnapshot(true);
+        _takeFullSnapshot(true);
       }
     }
   };
@@ -386,7 +386,7 @@ function record<T = eventWithTime>(
           mirror,
         });
 
-  takeFullSnapshot = (isCheckout = false) => {
+  _takeFullSnapshot = (isCheckout = false) => {
     wrappedEmit(
       wrapEvent({
         type: EventType.Meta,
@@ -644,7 +644,7 @@ function record<T = eventWithTime>(
     });
 
     const init = () => {
-      takeFullSnapshot();
+      _takeFullSnapshot();
       handlers.push(observe(document));
       recording = true;
     };
@@ -712,12 +712,14 @@ record.freezePage = () => {
   mutationBuffers.forEach((buf) => buf.freeze());
 };
 
-record.takeFullSnapshot = (isCheckout?: boolean) => {
+export function takeFullSnapshot(isCheckout?: boolean) {
   if (!recording) {
     throw new Error('please take full snapshot after start recording');
   }
-  takeFullSnapshot(isCheckout);
-};
+  _takeFullSnapshot(isCheckout);
+}
+
+record.takeFullSnapshot = takeFullSnapshot;
 
 record.mirror = mirror;
 

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -29,12 +29,10 @@ interface ISuite {
 
 interface IWindow extends Window {
   rrweb: {
-    record: ((
+    record: (
       options: recordOptions<eventWithTime>,
-    ) => listenerHandler | undefined) & {
-      takeFullSnapshot: (isCheckout?: boolean | undefined) => void;
-    };
-
+    ) => listenerHandler | undefined;
+    takeFullSnapshot: (isCheckout?: boolean | undefined) => void;
     freezePage(): void;
     addCustomEvent<T>(tag: string, payload: T): void;
   };
@@ -611,7 +609,7 @@ describe('record', function (this: ISuite) {
 
         setTimeout(() => {
           // When a full snapshot is checked out manually, all adoptedStylesheets should also be captured.
-          rrweb.record.takeFullSnapshot(true);
+          rrweb.takeFullSnapshot(true);
           resolve(undefined);
         }, 10);
       });


### PR DESCRIPTION
Currently, we use these from `record.xx`, which is not ideal thinking about treeshaking and lazy loading.

This moves these to be proper exports so we can use the in Replay without having to import `record` and everything that comes with it (=everything).