### PR TITLE
ref: Avoid cloning events to add `timestamp`

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -53,10 +53,9 @@ import {
 } from './error-handler';
 
 function wrapEvent(e: event): eventWithTime {
-  return {
-    ...e,
-    timestamp: nowTimestamp(),
-  };
+  const eWithTime = e as eventWithTime;
+  eWithTime.timestamp = nowTimestamp();
+  return eWithTime;
 }
 
 declare global {


### PR DESCRIPTION
We are always passing in fresh objects to this method, so instead of cloning this into a new object, we can just put the `timestamp` on the given object directly and return it, saving a bit of processing cost.