### PR TITLE
feat: Remove `hooks` related code, which is not used

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -96,7 +96,6 @@ function record<T = eventWithTime>(
     maskAttributeFn,
     maskInputFn,
     maskTextFn,
-    hooks,
     packFn,
     sampling = {},
     dataURLOptions = {},
@@ -462,149 +461,146 @@ function record<T = eventWithTime>(
     const handlers: listenerHandler[] = [];
 
     const observe = (doc: Document) => {
-      return callbackWrapper(initObservers)(
-        {
-          onMutation,
-          mutationCb: wrappedMutationEmit,
-          mousemoveCb: (positions, source) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source,
-                  positions,
-                },
-              }),
-            ),
-          mouseInteractionCb: (d) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.MouseInteraction,
-                  ...d,
-                },
-              }),
-            ),
-          scrollCb: wrappedScrollEmit,
-          viewportResizeCb: (d) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.ViewportResize,
-                  ...d,
-                },
-              }),
-            ),
-          inputCb: (v) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.Input,
-                  ...v,
-                },
-              }),
-            ),
-          mediaInteractionCb: (p) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.MediaInteraction,
-                  ...p,
-                },
-              }),
-            ),
-          styleSheetRuleCb: (r) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.StyleSheetRule,
-                  ...r,
-                },
-              }),
-            ),
-          styleDeclarationCb: (r) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.StyleDeclaration,
-                  ...r,
-                },
-              }),
-            ),
-          canvasMutationCb: wrappedCanvasMutationEmit,
-          fontCb: (p) =>
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.Font,
-                  ...p,
-                },
-              }),
-            ),
-          selectionCb: (p) => {
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.Selection,
-                  ...p,
-                },
-              }),
-            );
-          },
-          customElementCb: (c) => {
-            wrappedEmit(
-              wrapEvent({
-                type: EventType.IncrementalSnapshot,
-                data: {
-                  source: IncrementalSource.CustomElement,
-                  ...c,
-                },
-              }),
-            );
-          },
-          blockClass,
-          ignoreClass,
-          ignoreSelector,
-          maskAllText,
-          maskTextClass,
-          unmaskTextClass,
-          maskTextSelector,
-          unmaskTextSelector,
-          maskInputOptions,
-          inlineStylesheet,
-          sampling,
-          recordCanvas,
-          inlineImages,
-          userTriggeredOnInput,
-          collectFonts,
-          doc,
-          maskAttributeFn,
-          maskInputFn,
-          maskTextFn,
-          keepIframeSrcFn,
-          blockSelector,
-          unblockSelector,
-          slimDOMOptions,
-          dataURLOptions,
-          mirror,
-          iframeManager,
-          stylesheetManager,
-          shadowDomManager,
-          processedNodeManager,
-          canvasManager,
-          ignoreCSSAttributes,
-          plugins: [],
+      return callbackWrapper(initObservers)({
+        onMutation,
+        mutationCb: wrappedMutationEmit,
+        mousemoveCb: (positions, source) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source,
+                positions,
+              },
+            }),
+          ),
+        mouseInteractionCb: (d) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.MouseInteraction,
+                ...d,
+              },
+            }),
+          ),
+        scrollCb: wrappedScrollEmit,
+        viewportResizeCb: (d) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.ViewportResize,
+                ...d,
+              },
+            }),
+          ),
+        inputCb: (v) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.Input,
+                ...v,
+              },
+            }),
+          ),
+        mediaInteractionCb: (p) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.MediaInteraction,
+                ...p,
+              },
+            }),
+          ),
+        styleSheetRuleCb: (r) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.StyleSheetRule,
+                ...r,
+              },
+            }),
+          ),
+        styleDeclarationCb: (r) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.StyleDeclaration,
+                ...r,
+              },
+            }),
+          ),
+        canvasMutationCb: wrappedCanvasMutationEmit,
+        fontCb: (p) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.Font,
+                ...p,
+              },
+            }),
+          ),
+        selectionCb: (p) => {
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.Selection,
+                ...p,
+              },
+            }),
+          );
         },
-        hooks,
-      );
+        customElementCb: (c) => {
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.CustomElement,
+                ...c,
+              },
+            }),
+          );
+        },
+        blockClass,
+        ignoreClass,
+        ignoreSelector,
+        maskAllText,
+        maskTextClass,
+        unmaskTextClass,
+        maskTextSelector,
+        unmaskTextSelector,
+        maskInputOptions,
+        inlineStylesheet,
+        sampling,
+        recordCanvas,
+        inlineImages,
+        userTriggeredOnInput,
+        collectFonts,
+        doc,
+        maskAttributeFn,
+        maskInputFn,
+        maskTextFn,
+        keepIframeSrcFn,
+        blockSelector,
+        unblockSelector,
+        slimDOMOptions,
+        dataURLOptions,
+        mirror,
+        iframeManager,
+        stylesheetManager,
+        shadowDomManager,
+        processedNodeManager,
+        canvasManager,
+        ignoreCSSAttributes,
+        plugins: [],
+      });
     };
 
     iframeManager.addLoadListener((iframeEl) => {

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -24,32 +24,17 @@ import {
 } from '../utils';
 import type { observerParam, MutationBufferParam } from '../types';
 import {
-  mutationCallBack,
-  mousemoveCallBack,
   mousePosition,
-  mouseInteractionCallBack,
   MouseInteractions,
   PointerTypes,
   listenerHandler,
-  scrollCallback,
-  styleSheetRuleCallback,
-  viewportResizeCallback,
   inputValue,
-  inputCallback,
   hookResetter,
   IncrementalSource,
-  hooksParam,
-  Arguments,
-  mediaInteractionCallback,
   MediaInteractions,
-  canvasMutationCallback,
-  fontCallback,
   fontParam,
-  styleDeclarationCallback,
   IWindow,
   SelectionRange,
-  selectionCallback,
-  customElementCallback,
 } from '@sentry-internal/rrweb-types';
 import MutationBuffer from './mutation';
 import { callbackWrapper } from './error-handler';
@@ -1293,106 +1278,7 @@ function initCustomElementObserver({
   return restoreHandler;
 }
 
-function mergeHooks(o: observerParam, hooks: hooksParam) {
-  const {
-    mutationCb,
-    mousemoveCb,
-    mouseInteractionCb,
-    scrollCb,
-    viewportResizeCb,
-    inputCb,
-    mediaInteractionCb,
-    styleSheetRuleCb,
-    styleDeclarationCb,
-    canvasMutationCb,
-    fontCb,
-    selectionCb,
-    customElementCb,
-  } = o;
-  o.mutationCb = (...p: Arguments<mutationCallBack>) => {
-    if (hooks.mutation) {
-      hooks.mutation(...p);
-    }
-    mutationCb(...p);
-  };
-  o.mousemoveCb = (...p: Arguments<mousemoveCallBack>) => {
-    if (hooks.mousemove) {
-      hooks.mousemove(...p);
-    }
-    mousemoveCb(...p);
-  };
-  o.mouseInteractionCb = (...p: Arguments<mouseInteractionCallBack>) => {
-    if (hooks.mouseInteraction) {
-      hooks.mouseInteraction(...p);
-    }
-    mouseInteractionCb(...p);
-  };
-  o.scrollCb = (...p: Arguments<scrollCallback>) => {
-    if (hooks.scroll) {
-      hooks.scroll(...p);
-    }
-    scrollCb(...p);
-  };
-  o.viewportResizeCb = (...p: Arguments<viewportResizeCallback>) => {
-    if (hooks.viewportResize) {
-      hooks.viewportResize(...p);
-    }
-    viewportResizeCb(...p);
-  };
-  o.inputCb = (...p: Arguments<inputCallback>) => {
-    if (hooks.input) {
-      hooks.input(...p);
-    }
-    inputCb(...p);
-  };
-  o.mediaInteractionCb = (...p: Arguments<mediaInteractionCallback>) => {
-    if (hooks.mediaInteaction) {
-      hooks.mediaInteaction(...p);
-    }
-    mediaInteractionCb(...p);
-  };
-  o.styleSheetRuleCb = (...p: Arguments<styleSheetRuleCallback>) => {
-    if (hooks.styleSheetRule) {
-      hooks.styleSheetRule(...p);
-    }
-    styleSheetRuleCb(...p);
-  };
-  o.styleDeclarationCb = (...p: Arguments<styleDeclarationCallback>) => {
-    if (hooks.styleDeclaration) {
-      hooks.styleDeclaration(...p);
-    }
-    styleDeclarationCb(...p);
-  };
-  o.canvasMutationCb = (...p: Arguments<canvasMutationCallback>) => {
-    if (hooks.canvasMutation) {
-      hooks.canvasMutation(...p);
-    }
-    canvasMutationCb(...p);
-  };
-  o.fontCb = (...p: Arguments<fontCallback>) => {
-    if (hooks.font) {
-      hooks.font(...p);
-    }
-    fontCb(...p);
-  };
-  o.selectionCb = (...p: Arguments<selectionCallback>) => {
-    if (hooks.selection) {
-      hooks.selection(...p);
-    }
-    selectionCb(...p);
-  };
-  o.customElementCb = (...c: Arguments<customElementCallback>) => {
-    if (hooks.customElement) {
-      hooks.customElement(...c);
-    }
-    customElementCb(...c);
-  };
-}
-
-export function initObservers(
-  o: observerParam,
-  hooks: hooksParam = {},
-): listenerHandler {
+export function initObservers(o: observerParam): listenerHandler {
   const currentWindow = o.doc.defaultView; // basically document.window
   if (!currentWindow) {
     return () => {
@@ -1400,7 +1286,7 @@ export function initObservers(
     };
   }
 
-  mergeHooks(o, hooks);
+  // We do not use hooks, so we skip this
   const mutationObserver = initMutationObserver(o, o.doc);
   const mousemoveHandler = initMoveObserver(o);
   const mouseInteractionHandler = initMouseInteractionObserver(o);


### PR DESCRIPTION
We do not use this, so removing this reduces some overhead & bundle size.