### PR TITLE
feat(replay): Skip `addHoverClass` when stylesheet is >= 1MB

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -69,6 +69,12 @@ export function addHoverClass(cssText: string, cache: BuildCache): string {
   const cachedStyle = cache?.stylesWithHoverClass.get(cssText);
   if (cachedStyle) return cachedStyle;
 
+  if (cssText.length >= 1_000_000) {
+    // Skip adding hover class for large stylesheets, otherwise we will run
+    // into perf issues that will block main thread
+    return cssText;
+  }
+
   const ast = parse(cssText, {
     silent: true,
   });


### PR DESCRIPTION
Large stylesheets will cause `addHoverClass` to block the main UI thread when viewing a replay. Turn this off when stylesheet is >= 1MB.
