### PR TITLE
upstream: Feat: Add support for replaying :defined pseudo-class of custom elements (#1155)

### DIFF
--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -271,7 +271,6 @@ export class IframeManager implements IframeManagerInterface {
         }
       }
     }
-
     return false;
   }
 

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -1242,12 +1242,8 @@ function initCustomElementObserver({
   customElementCb,
 }: observerParam): listenerHandler {
   const win = doc.defaultView as IWindow;
-  if (!win || !win.customElements) {
-    return () => {
-      // do nothing
-    };
-  }
-
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  if (!win || !win.customElements) return () => {};
   const restoreHandler = patch(
     win.customElements,
     'define',


### PR DESCRIPTION
cherry-picks https://github.com/rrweb-io/rrweb/pull/1155 which was merged in our fork in https://github.com/getsentry/rrweb/pull/107 (prior to #1155 being merged). This results in only 2 small stylistic changes.

Feat: Add support for replaying :defined pseudo-class of custom elements #1155