### PR TITLE
Revert "fix: isCheckout is not included in fullsnapshot event (#1141)"

### DIFF
--- a/.changeset/stupid-ghosts-help.md
+++ b/.changeset/stupid-ghosts-help.md
@@ -1,5 +1,0 @@
----
-'rrweb': patch
----
-
-Fix: isCheckout is missed in all fullsnapshot events

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -455,7 +455,6 @@ function record<T = eventWithTime>(
           initialOffset: getWindowScroll(window),
         },
       }),
-      isCheckout,
     );
     mutationBuffers.forEach((buf) => buf.unlock()); // generate & emit any mutations that happened during snapshotting, as can now apply against the newly built mirror
 


### PR DESCRIPTION
This reverts commit 3416c3a769e2bd2ddfbb88f5c4ff139871c567be.


From [my comment here](https://github.com/rrweb-io/rrweb/issues/1242#issuecomment-1847812047)

> I only used translate on the OP but if I understand correctly, when we call `takeFullSnapshot(true)`, we will receive two distinct events with the `isCheckout` arg as `true`. Looking at the blame this is due to #1141.

> If you use `checkoutEvery...` and rely on `isCheckout` to reset existing events, this means that the [`Meta` event](https://github.com/rrweb-io/rrweb/blob/master/packages/rrweb/src/record/index.ts#L352-L362) will be lost because [the `FullSnapshot`](https://github.com/rrweb-io/rrweb/blob/master/packages/rrweb/src/record/index.ts#L408-L417) occurs afterwards, and `isCheckout` is true for both events. Losing the `Meta` event means that the replayer will be unable to set its dimensions, making the replay look broken.
