### PR TITLE
feat(canvas): Bind `mutationCb` outside of `getCanvasManager`

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -337,14 +337,17 @@ function record<T = eventWithTime>(
 
   const processedNodeManager = new ProcessedNodeManager();
 
-  const canvasManager: CanvasManagerInterface = _getCanvasManager(getCanvasManager, {
-    recordCanvas,
-    blockClass,
-    blockSelector,
-    unblockSelector,
-    sampling: sampling['canvas'],
-    dataURLOptions,
-  });
+  const canvasManager: CanvasManagerInterface = _getCanvasManager(
+    getCanvasManager,
+    {
+      recordCanvas,
+      blockClass,
+      blockSelector,
+      unblockSelector,
+      sampling: sampling['canvas'],
+      dataURLOptions,
+    },
+  );
 
   const shadowDomManager: ShadowDomManagerInterface =
     typeof __RRWEB_EXCLUDE_SHADOW_DOM__ === 'boolean' &&
@@ -737,11 +740,15 @@ type PublicGetCanvasManagerOptions = Omit<
   PrivateOptions
 >;
 
-interface PrivateGetCanvasManagerOptions extends PublicGetCanvasManagerOptions, Pick<CanvasManagerConstructorOptions, PrivateOptions> {}
+interface PrivateGetCanvasManagerOptions
+  extends PublicGetCanvasManagerOptions,
+    Pick<CanvasManagerConstructorOptions, PrivateOptions> {}
 
 function _getCanvasManager(
-  getCanvasManagerFn: undefined | ((options: PrivateGetCanvasManagerOptions) => CanvasManagerInterface),
-  options: PublicGetCanvasManagerOptions
+  getCanvasManagerFn:
+    | undefined
+    | ((options: PrivateGetCanvasManagerOptions) => CanvasManagerInterface),
+  options: PublicGetCanvasManagerOptions,
 ) {
   return getCanvasManagerFn
     ? getCanvasManagerFn({

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -337,16 +337,14 @@ function record<T = eventWithTime>(
 
   const processedNodeManager = new ProcessedNodeManager();
 
-  const canvasManager: CanvasManagerInterface = getCanvasManager
-    ? getCanvasManager({
-        recordCanvas,
-        blockClass,
-        blockSelector,
-        unblockSelector,
-        sampling: sampling['canvas'],
-        dataURLOptions,
-      })
-    : new CanvasManagerNoop();
+  const canvasManager: CanvasManagerInterface = _getCanvasManager(getCanvasManager, {
+    recordCanvas,
+    blockClass,
+    blockSelector,
+    unblockSelector,
+    sampling: sampling['canvas'],
+    dataURLOptions,
+  });
 
   const shadowDomManager: ShadowDomManagerInterface =
     typeof __RRWEB_EXCLUDE_SHADOW_DOM__ === 'boolean' &&
@@ -733,27 +731,39 @@ record.takeFullSnapshot = takeFullSnapshot;
 
 export default record;
 
-const wrappedCanvasMutationEmit = (p: canvasMutationParam) =>
-  wrappedEmit(
-    wrapEvent({
-      type: EventType.IncrementalSnapshot,
-      data: {
-        source: IncrementalSource.CanvasMutation,
-        ...p,
-      },
-    }),
-  );
+type PrivateOptions = 'mutationCb' | 'win' | 'mirror';
+type PublicGetCanvasManagerOptions = Omit<
+  CanvasManagerConstructorOptions,
+  PrivateOptions
+>;
+
+interface PrivateGetCanvasManagerOptions extends PublicGetCanvasManagerOptions, Pick<CanvasManagerConstructorOptions, PrivateOptions> {}
+
+function _getCanvasManager(
+  getCanvasManagerFn: undefined | ((options: PrivateGetCanvasManagerOptions) => CanvasManagerInterface),
+  options: PublicGetCanvasManagerOptions
+) {
+  return getCanvasManagerFn
+    ? getCanvasManagerFn({
+        ...options,
+        mirror,
+        win: window,
+        mutationCb: (p: canvasMutationParam) =>
+          wrappedEmit(
+            wrapEvent({
+              type: EventType.IncrementalSnapshot,
+              data: {
+                source: IncrementalSource.CanvasMutation,
+                ...p,
+              },
+            }),
+          ),
+      })
+    : new CanvasManagerNoop();
+}
 
 export function getCanvasManager(
-  options: Omit<
-    CanvasManagerConstructorOptions,
-    'mutationCb' | 'win' | 'mirror'
-  >,
+  options: PublicGetCanvasManagerOptions,
 ): CanvasManagerInterface {
-  return new CanvasManager({
-    ...options,
-    mutationCb: wrappedCanvasMutationEmit,
-    win: window,
-    mirror,
-  });
+  return new CanvasManager(options as CanvasManagerConstructorOptions);
 }


### PR DESCRIPTION
From what I can tell, `record` ends up getting bundled separate from `getCanvasManager` in user-land code and canvas mutation events end up not being transmitted because `_wrappedEmit` does not get set and it will hold the wrong `mirror` reference.
