### PR TITLE
build: Build for ES2020

### DIFF
--- a/packages/rrdom-nodejs/tsconfig.json
+++ b/packages/rrdom-nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "ES6",
+    "target": "ES2020",
     "module": "commonjs",
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/packages/rrdom/tsconfig.json
+++ b/packages/rrdom/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "ES6",
+    "target": "ES2020",
     "module": "commonjs",
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/packages/rrvideo/tsconfig.json
+++ b/packages/rrvideo/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "ES6",
+    "target": "ES2020",
     "module": "commonjs",
     "declaration": true,
     "sourceMap": true,

--- a/packages/rrweb-snapshot/tsconfig.json
+++ b/packages/rrweb-snapshot/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "target": "ES6",
+    "target": "ES2020",
     "moduleResolution": "Node",
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/packages/rrweb/tsconfig.json
+++ b/packages/rrweb/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Node",
-    "target": "ES6",
+    "target": "ES2020",
     "noImplicitAny": true,
     "strictNullChecks": true,
     "removeComments": true,

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "ES6",
+    "target": "ES2020",
     "module": "commonjs",
     "noImplicitAny": true,
     "strictNullChecks": true,

--- a/packages/web-extension/tsconfig.json
+++ b/packages/web-extension/tsconfig.json
@@ -3,7 +3,7 @@
     "composite": true,
     "baseUrl": ".",
     "module": "ESNext",
-    "target": "es2016",
+    "target": "ES2020",
     "lib": [
       "DOM",
       "ESNext"


### PR DESCRIPTION
Avoid already polyfilling stuff in here - we rather do this in the Sentry SDK directly.

Currently, we are polyfilling things separately here (e.g. rest parameters, async/await), but we would polyfill stuff we need more efficiently in the Sentry SDK anyhow. So this should reduce bundle size a bit.