### PR TITLE
feat: Bundle canvas worker manually

### DIFF
--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -41,7 +41,6 @@
     "rollup": "^2.56.3",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
-    "rollup-plugin-web-worker-loader": "^1.6.1",
     "ts-jest": "^27.1.3"
   },
   "dependencies": {

--- a/packages/rrdom-nodejs/rollup.config.js
+++ b/packages/rrdom-nodejs/rollup.config.js
@@ -2,7 +2,6 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
-import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import pkg from './package.json';
 
 function toMinPath(path) {
@@ -12,10 +11,6 @@ function toMinPath(path) {
 const basePlugins = [
   resolve({ browser: true }),
   commonjs(),
-
-  // supports bundling `web-worker:..filename` from rrweb
-  webWorkerLoader(),
-
   typescript({
     tsconfigOverride: { compilerOptions: { module: 'ESNext' } },
   }),

--- a/packages/rrdom-nodejs/tsconfig.json
+++ b/packages/rrdom-nodejs/tsconfig.json
@@ -25,7 +25,6 @@
   "include": [
     "src",
     "test.d.ts",
-    "../rrweb/src/record/workers/workers.d.ts",
     "../rrweb/src/record/constructable-stylesheets.d.ts"
   ],
   "references": [

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -45,7 +45,6 @@
     "rollup": "^2.56.3",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
-    "rollup-plugin-web-worker-loader": "^1.6.1",
     "ts-jest": "^27.1.3"
   },
   "dependencies": {

--- a/packages/rrdom/rollup.config.js
+++ b/packages/rrdom/rollup.config.js
@@ -2,7 +2,6 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
-import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import pkg from './package.json';
 
 function toMinPath(path) {
@@ -12,10 +11,6 @@ function toMinPath(path) {
 const basePlugins = [
   resolve({ browser: true }),
   commonjs(),
-
-  // supports bundling `web-worker:..filename` from rrweb
-  webWorkerLoader(),
-
   typescript({
     tsconfigOverride: { compilerOptions: { module: 'ESNext' } },
   }),

--- a/packages/rrdom/tsconfig.json
+++ b/packages/rrdom/tsconfig.json
@@ -32,7 +32,6 @@
   ],
   "include": [
     "src",
-    "../rrweb/src/record/workers/workers.d.ts",
     "../rrweb/src/record/constructable-stylesheets.d.ts"
   ]
 }

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -15,7 +15,6 @@
     "rollup-plugin-svelte": "^7.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
-    "rollup-plugin-web-worker-loader": "^1.6.1",
     "sirv-cli": "^0.4.4",
     "svelte": "^3.59.2",
     "svelte-check": "^3.0.1",

--- a/packages/rrweb-player/rollup.config.js
+++ b/packages/rrweb-player/rollup.config.js
@@ -4,7 +4,6 @@ import commonjs from '@rollup/plugin-commonjs';
 import livereload from 'rollup-plugin-livereload';
 import { terser } from 'rollup-plugin-terser';
 import sveltePreprocess from 'svelte-preprocess';
-import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import typescript from 'rollup-plugin-typescript2';
 import pkg from './package.json';
 import css from 'rollup-plugin-css-only';
@@ -68,9 +67,6 @@ export default entries.map((output) => ({
     }),
 
     commonjs(),
-
-    // supports bundling `web-worker:..filename` from rrweb
-    webWorkerLoader(),
 
     typescript(),
 

--- a/packages/rrweb-player/tsconfig.json
+++ b/packages/rrweb-player/tsconfig.json
@@ -7,7 +7,6 @@
     "node_modules/*",
     "__sapper__/*",
     "public/*",
-    "../rrweb/src/record/workers/workers.d.ts"
   ],
   "compilerOptions": {
     "composite": true

--- a/packages/rrweb-worker/.eslintrc.json
+++ b/packages/rrweb-worker/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["../../.eslintrc.js"],
+  "rules": {
+    "prefer-template": "off",
+    "@typescript-eslint/restrict-plus-operands": "off"
+  }
+}

--- a/packages/rrweb-worker/.gitignore
+++ b/packages/rrweb-worker/.gitignore
@@ -1,0 +1,18 @@
+.vscode
+.idea
+node_modules
+package-lock.json
+# yarn.lock
+*.tsbuildinfo
+build
+dist
+es
+lib
+typings
+
+temp
+
+*.log
+
+.env
+__diff_output__

--- a/packages/rrweb-worker/package.json
+++ b/packages/rrweb-worker/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@sentry-internal/rrweb-worker",
+  "version": "2.6.0",
+  "description": "Worker for rrweb",
+  "main": "lib/rrweb-worker/index.cjs",
+  "module": "es/rrweb-worker/index.js",
+  "types": "typings/index.d.ts",
+  "sideEffects": false,
+  "private": true,
+  "scripts": {
+    "dev": "yarn bundle --watch",
+    "build:tarball": "npm pack",
+    "bundle": "rollup --config",
+    "typings": "tsc -p tsconfig.types.json",
+    "prepare": "npm run typings && npm run bundle",
+    "check-types": "tsc -noEmit",
+    "lint": "yarn eslint src"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getsentry/rrweb.git"
+  },
+  "author": "Sentry",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/getsentry/rrweb/issues"
+  },
+  "dependencies": {},
+  "engines": {
+    "node": ">=12"
+  }
+}

--- a/packages/rrweb-worker/package.json
+++ b/packages/rrweb-worker/package.json
@@ -25,7 +25,10 @@
   "bugs": {
     "url": "https://github.com/getsentry/rrweb/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@sentry-internal/rrweb-snapshot": "2.6.0",
+    "@sentry-internal/rrweb-types": "2.6.0"
+  },
   "engines": {
     "node": ">=12"
   }

--- a/packages/rrweb-worker/rollup.config.js
+++ b/packages/rrweb-worker/rollup.config.js
@@ -1,0 +1,83 @@
+import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
+import typescript from 'rollup-plugin-typescript2';
+import { defineConfig } from 'rollup';
+import { terser } from 'rollup-plugin-terser';
+
+const workerStrBaseConfig = {
+  input: ['./src/_image-bitmap-data-url-worker.ts'],
+  treeshake: 'smallest',
+  plugins: [
+    commonjs(),
+    typescript({
+      tsconfig: './tsconfig.json',
+      inlineSourceMap: false,
+      sourceMap: false,
+      inlineSources: false,
+    }),
+    resolve(),
+    terser({
+      mangle: {
+        module: true,
+      },
+    }),
+    {
+      name: 'worker-to-string',
+      renderChunk(code) {
+        return `export default \`${code}\`;`;
+      },
+    },
+  ],
+};
+
+const indexBaseConfig = {
+  input: ['./src/index.ts'],
+  treeshake: 'smallest',
+  external: ['./image-bitmap-data-url-worker'],
+  plugins: [
+    typescript({
+      tsconfig: './tsconfig.json',
+      inlineSourceMap: false,
+      sourceMap: false,
+      inlineSources: false,
+    }),
+    terser({
+      mangle: {
+        module: true,
+      },
+    }),
+  ],
+};
+
+const config = defineConfig([
+  {
+    ...workerStrBaseConfig,
+    output: {
+      file: './es/rrweb-worker/image-bitmap-data-url-worker.js',
+      format: 'esm',
+    },
+  },
+  {
+    ...workerStrBaseConfig,
+    output: {
+      file: './lib/rrweb-worker/image-bitmap-data-url-worker.cjs',
+      format: 'cjs',
+    },
+  },
+  {
+    ...indexBaseConfig,
+    output: {
+      file: './es/rrweb-worker/index.js',
+      format: 'esm',
+    },
+  },
+  {
+    ...indexBaseConfig,
+    output: {
+      file: './lib/rrweb-worker/index.cjs',
+      format: 'cjs',
+    },
+  },
+]);
+
+export default config;

--- a/packages/rrweb-worker/src/_image-bitmap-data-url-worker.ts
+++ b/packages/rrweb-worker/src/_image-bitmap-data-url-worker.ts
@@ -28,7 +28,7 @@ async function getTransparentBlobFor(
   height: number,
   dataURLOptions: DataURLOptions,
 ): Promise<string> {
-  const id = `${width}-${height}`;
+  const id = width + '-' + height;
   if ('OffscreenCanvas' in globalThis) {
     if (transparentBlobMap.has(id)) return transparentBlobMap.get(id)!;
     const offscreen = new OffscreenCanvas(width, height);

--- a/packages/rrweb-worker/src/image-bitmap-data-url-worker.ts
+++ b/packages/rrweb-worker/src/image-bitmap-data-url-worker.ts
@@ -1,0 +1,3 @@
+// This is replaced at build-time with the content from _image-bitmap-data-url-worker.ts, wrapped as a string.
+// This is just a placeholder so that types etc. are correct.
+export default '' as string;

--- a/packages/rrweb-worker/src/index.ts
+++ b/packages/rrweb-worker/src/index.ts
@@ -1,0 +1,9 @@
+import workerString from './image-bitmap-data-url-worker';
+
+/**
+ * Get the URL for a web worker.
+ */
+export function getImageBitmapDataUrlWorkerURL(): string {
+  const workerBlob = new Blob([workerString]);
+  return URL.createObjectURL(workerBlob);
+}

--- a/packages/rrweb-worker/tsconfig.json
+++ b/packages/rrweb-worker/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2020",
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "removeComments": true,
+    "preserveConstEnums": true,
+    "rootDir": "src",
+    "outDir": "build",
+    "lib": ["webworker", "scripthost"],
+    "allowSyntheticDefaultImports": true,
+    "declarationMap": false,
+    "skipLibCheck": true,
+    "composite": true
+  },
+  "references": [],
+  "exclude": [
+    "test",
+    "scripts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/packages/rrweb-worker/tsconfig.json
+++ b/packages/rrweb-worker/tsconfig.json
@@ -9,16 +9,25 @@
     "preserveConstEnums": true,
     "rootDir": "src",
     "outDir": "build",
-    "lib": ["webworker", "scripthost"],
+    "lib": [
+      "webworker",
+      "scripthost"
+    ],
     "allowSyntheticDefaultImports": true,
     "declarationMap": false,
     "skipLibCheck": true,
     "composite": true
   },
-  "references": [],
+  "references": [
+    {
+      "path": "../rrweb-snapshot"
+    }
+  ],
   "exclude": [
     "test",
     "scripts"
   ],
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/packages/rrweb-worker/tsconfig.types.json
+++ b/packages/rrweb-worker/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/*.ts"],
+  "compilerOptions": {
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "typings"
+  }
+}

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -73,13 +73,13 @@
     "rollup-plugin-postcss": "^3.1.1",
     "rollup-plugin-rename-node-modules": "^1.3.1",
     "rollup-plugin-typescript2": "^0.31.2",
-    "rollup-plugin-web-worker-loader": "^1.6.1",
     "simple-peer-light": "^9.10.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "tslib": "^2.3.1"
   },
   "dependencies": {
+    "@sentry-internal/rrweb-worker": "2.6.0",
     "@sentry-internal/rrdom": "2.6.0",
     "@sentry-internal/rrweb-snapshot": "2.6.0",
     "@sentry-internal/rrweb-types": "2.6.0",

--- a/packages/rrweb/rollup.config.js
+++ b/packages/rrweb/rollup.config.js
@@ -3,7 +3,6 @@ import esbuild from 'rollup-plugin-esbuild';
 import resolve from '@rollup/plugin-node-resolve';
 import postcss from 'rollup-plugin-postcss';
 import renameNodeModules from 'rollup-plugin-rename-node-modules';
-import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import pkg from './package.json';
 
 function toRecordPath(path) {
@@ -122,11 +121,6 @@ function getPlugins(options = {}) {
   const { minify = false, sourceMap = false } = options;
   return [
     resolve({ browser: true }),
-    webWorkerLoader({
-      targetPlatform: 'browser',
-      inline: true,
-      sourceMap,
-    }),
     esbuild({
       minify,
     }),
@@ -142,9 +136,6 @@ function getPlugins(options = {}) {
 for (const c of baseConfigs) {
   const basePlugins = [
     resolve({ browser: true }),
-
-    // supports bundling `web-worker:..filename`
-    webWorkerLoader({ targetPlatform: 'browser' }),
 
     typescript(),
   ];

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -20,6 +20,7 @@ import initCanvas2DMutationObserver from './2d';
 import initCanvasContextObserver from './canvas';
 import initCanvasWebGLMutationObserver from './webgl';
 import { getImageBitmapDataUrlWorkerURL } from '@sentry-internal/rrweb-worker';
+import { callbackWrapper } from '../../error-handler';
 
 export type RafStamps = { latestId: number; invokeId: number | null };
 
@@ -110,15 +111,15 @@ export class CanvasManager implements CanvasManagerInterface {
     this.mutationCb = options.mutationCb;
     this.mirror = options.mirror;
 
-    if (recordCanvas && sampling === 'all')
-      this.initCanvasMutationObserver(
-        win,
-        blockClass,
-        blockSelector,
-        unblockSelector,
-      );
-    if (recordCanvas && typeof sampling === 'number')
-      try {
+    callbackWrapper(() => {
+      if (recordCanvas && sampling === 'all')
+        this.initCanvasMutationObserver(
+          win,
+          blockClass,
+          blockSelector,
+          unblockSelector,
+        );
+      if (recordCanvas && typeof sampling === 'number')
         this.initCanvasFPSObserver(
           sampling,
           win,
@@ -129,9 +130,7 @@ export class CanvasManager implements CanvasManagerInterface {
             dataURLOptions,
           },
         );
-      } catch {
-        // Error when initializing canvas...
-      }
+    })();
   }
 
   private processMutation: canvasManagerMutationCallback = (

--- a/packages/rrweb/src/record/workers/tsconfig.json
+++ b/packages/rrweb/src/record/workers/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "lib": ["webworker"]
-  },
-  "exclude": ["workers.d.ts"]
-}

--- a/packages/rrweb/src/record/workers/workers.d.ts
+++ b/packages/rrweb/src/record/workers/workers.d.ts
@@ -1,4 +1,0 @@
-declare module 'web-worker:*' {
-  const WorkerFactory: new () => Worker;
-  export default WorkerFactory;
-}

--- a/packages/rrweb/tsconfig.json
+++ b/packages/rrweb/tsconfig.json
@@ -20,6 +20,9 @@
   },
   "references": [
     {
+      "path": "../rrweb-worker"
+    },
+    {
       "path": "../rrdom"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,10 @@
     },
     {
       "path": "packages/web-extension"
-    }
+    },
+    {
+      "path": "packages/rrweb-worker"
+    },
   ],
   "files": [],
   "include": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12920,11 +12920,6 @@ rollup-plugin-typescript2@^0.31.2:
     resolve "^1.20.0"
     tslib "^2.3.1"
 
-rollup-plugin-web-worker-loader@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-1.6.1.tgz"
-  integrity sha512-4QywQSz1NXFHKdyiou16mH3ijpcfLtLGOrAqvAqu1Gx+P8+zj+3gwC2BSL/VW1d+LW4nIHC8F7d7OXhs9UdR2A==
-
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5253,9 +5253,14 @@ csso@^4.0.2:
   dependencies:
     css-tree "^1.1.2"
 
-cssom@^0.4.4, cssom@^0.5.0, "cssom@https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz":
+cssom@^0.4.4, "cssom@https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz":
   version "0.6.0"
   resolved "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
+
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
 
 cssom@~0.3.6:
   version "0.3.8"


### PR DESCRIPTION
While trying to get the ReplayCanvas integration to properly tree shake, I noticed that the current way this worker is built is not ideal, and maybe is not treeshakeable properly. We use a rollup plugin to convert the worker to a base64 string, which a) is more verbose than just having the worker be a plain string, and b) possibly is not tree shakeable.

This refactors the worker to work the same way as the compression worker in Sentry - we build it to a string and use that in rrweb. This is a bit more complicated, from a setup perspective, but gives us full control over the worker build.