### PR TITLE
meta(changelog): Update changelog for 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.7.0
+
+- ref: Avoid async in canvas (#143)
+- feat: Bundle canvas worker manually (#144)
+- build: Build for ES2020 (#142)
+
 ## 2.6.0
 
 ### Various fixes & improvements


### PR DESCRIPTION
Some build improvements, let's see if they help with the canvas manager tree shaking...