### PR TITLE
build: Do not build rrweb-worker package

### DIFF
--- a/packages/rrweb-worker/package.json
+++ b/packages/rrweb-worker/package.json
@@ -9,7 +9,6 @@
   "private": true,
   "scripts": {
     "dev": "yarn bundle --watch",
-    "build:tarball": "npm pack",
     "bundle": "rollup --config",
     "typings": "tsc -p tsconfig.types.json",
     "prepare": "npm run typings && npm run bundle",


### PR DESCRIPTION
I think this is what blew up the build (https://github.com/getsentry/publish/actions/runs/7277054052/job/19828232668), seems that craft tried to publish this incorrectly to NPM 😬 