### PR TITLE
feat(replay): Catch exceptions from `getCanvasManager`

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -750,23 +750,28 @@ function _getCanvasManager(
     | ((options: PrivateGetCanvasManagerOptions) => CanvasManagerInterface),
   options: PublicGetCanvasManagerOptions,
 ) {
-  return getCanvasManagerFn
-    ? getCanvasManagerFn({
-        ...options,
-        mirror,
-        win: window,
-        mutationCb: (p: canvasMutationParam) =>
-          wrappedEmit(
-            wrapEvent({
-              type: EventType.IncrementalSnapshot,
-              data: {
-                source: IncrementalSource.CanvasMutation,
-                ...p,
-              },
-            }),
-          ),
-      })
-    : new CanvasManagerNoop();
+  try {
+    return getCanvasManagerFn
+      ? getCanvasManagerFn({
+          ...options,
+          mirror,
+          win: window,
+          mutationCb: (p: canvasMutationParam) =>
+            wrappedEmit(
+              wrapEvent({
+                type: EventType.IncrementalSnapshot,
+                data: {
+                  source: IncrementalSource.CanvasMutation,
+                  ...p,
+                },
+              }),
+            ),
+        })
+      : new CanvasManagerNoop();
+  } catch {
+    console.warn('Unable to initialize CanvasManager');
+    return new CanvasManagerNoop();
+  }
 }
 
 export function getCanvasManager(


### PR DESCRIPTION
Catches exceptions thrown from `getCanvasManager` and returns the Noop version so that replay recording can continue.

Fixes https://sentry.sentry.io/issues/4745239659/?project=11276
