### PR TITLE
feat(replays): Add manual canvas snapshot function

### DIFF
--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -32,4 +32,5 @@ export {
   freezePage,
   addCustomEvent,
   getCanvasManager,
+  _getCanvasManager,
 } from './record';

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -744,7 +744,7 @@ interface PrivateGetCanvasManagerOptions
   extends PublicGetCanvasManagerOptions,
     Pick<CanvasManagerConstructorOptions, PrivateOptions> {}
 
-function _getCanvasManager(
+export function _getCanvasManager(
   getCanvasManagerFn:
     | undefined
     | ((options: PrivateGetCanvasManagerOptions) => CanvasManagerInterface),

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -38,7 +38,7 @@ export interface CanvasManagerInterface {
   snapshot(
     canvasElement: HTMLCanvasElement,
     dataURLOptions: DataURLOptions,
-    sampling?: number | 'all',
+    sampling?: number,
   ): void;
 }
 


### PR DESCRIPTION
Adds a snapshot canvas function that allows you to manually snapshot canvas elements, which enables recording of 3d and webgl canvas