### PR TITLE
build(ci): Ensure we build properly before building tarballs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Build Project
+        run: NODE_OPTIONS='--max-old-space-size=4096' yarn build:all
+
       - name: Build Tarballs
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"


### PR DESCRIPTION
Not 100% sure, but I _think_ this is the cause of publish failing here: https://github.com/getsentry/rrweb/actions/runs/7277648321/job/19830279475