### PR TITLE
build: Fix build issue with rrweb & rrweb-worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.7.3
+
+- Fix build issue with rrweb & rrweb-worker
+
 ## 2.7.2
 
 - fix(rrweb): Use unpatched requestAnimationFrame when possible [#150](https://github.com/getsentry/rrweb/pull/150)

--- a/packages/rrweb-worker/tsconfig.json
+++ b/packages/rrweb-worker/tsconfig.json
@@ -21,6 +21,9 @@
   "references": [
     {
       "path": "../rrweb-snapshot"
+    },
+    {
+      "path": "../types"
     }
   ],
   "exclude": [

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -49,6 +49,7 @@
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.1.3",
+    "@sentry-internal/rrweb-worker": "2.7.2",
     "@types/chai": "^4.1.6",
     "@types/dom-mediacapture-transform": "0.1.4",
     "@types/inquirer": "^8.2.1",
@@ -82,7 +83,6 @@
     "@sentry-internal/rrdom": "2.7.2",
     "@sentry-internal/rrweb-snapshot": "2.7.2",
     "@sentry-internal/rrweb-types": "2.7.2",
-    "@sentry-internal/rrweb-worker": "2.7.2",
     "@types/css-font-loading-module": "0.0.7",
     "@xstate/fsm": "^1.4.0",
     "base64-arraybuffer": "^1.0.1",

--- a/packages/rrweb/tsconfig.json
+++ b/packages/rrweb/tsconfig.json
@@ -20,9 +20,6 @@
   },
   "references": [
     {
-      "path": "../rrweb-worker"
-    },
-    {
       "path": "../rrdom"
     },
     {
@@ -30,6 +27,9 @@
     },
     {
       "path": "../types"
+    },
+    {
+      "path": "../rrweb-worker"
     }
   ],
   "exclude": [


### PR DESCRIPTION
It is now complaining:

```
error Couldn't find package "@sentry-internal/rrweb-worker@2.7.2" required by "@sentry-internal/rrweb@2.7.2" on the "npm" registry.
```

hopefully this is fixed by making this a devDependency.