### PR TITLE
feat: Remove `getCanvasManager`, export `CanvasManager` class directly

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -7,9 +7,9 @@ module.exports = [
     gzip: true
   },
   {
-    name: 'rrweb - record & getCanvasManager only (gzipped)',
+    name: 'rrweb - record & CanvasManager only (gzipped)',
     path: 'packages/rrweb/es/rrweb/packages/rrweb/src/entries/all.js',
-    import: '{ record, getCanvasManager }',
+    import: '{ record, CanvasManager }',
     gzip: true
   },
   {

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -31,5 +31,7 @@ export {
   mirror,
   freezePage,
   addCustomEvent,
-  getCanvasManager,
 } from './record';
+
+export {CanvasManager} from './record/observers/canvas/canvas-manager';
+export type {CanvasManagerConstructorOptions} from './record/observers/canvas/canvas-manager';

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -26,12 +26,7 @@ export { record, Replayer, utils, canvasMutation };
 
 export { deserializeArg } from './replay/canvas/deserialize-args';
 
-export {
-  takeFullSnapshot,
-  mirror,
-  freezePage,
-  addCustomEvent,
-} from './record';
+export { takeFullSnapshot, mirror, freezePage, addCustomEvent } from './record';
 
-export {CanvasManager} from './record/observers/canvas/canvas-manager';
-export type {CanvasManagerConstructorOptions} from './record/observers/canvas/canvas-manager';
+export { CanvasManager } from './record/observers/canvas/canvas-manager';
+export type { CanvasManagerConstructorOptions } from './record/observers/canvas/canvas-manager';

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -26,7 +26,12 @@ export { record, Replayer, utils, canvasMutation };
 
 export { deserializeArg } from './replay/canvas/deserialize-args';
 
-export { takeFullSnapshot, mirror, freezePage, addCustomEvent } from './record';
+export {
+  takeFullSnapshot,
+  mirror,
+  freezePage,
+  addCustomEvent,
+} from './record';
 
 export { CanvasManager } from './record/observers/canvas/canvas-manager';
 export type { CanvasManagerConstructorOptions } from './record/observers/canvas/canvas-manager';

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -26,12 +26,7 @@ export { record, Replayer, utils, canvasMutation };
 
 export { deserializeArg } from './replay/canvas/deserialize-args';
 
-export {
-  takeFullSnapshot,
-  mirror,
-  freezePage,
-  addCustomEvent,
-} from './record';
+export { takeFullSnapshot, mirror, freezePage, addCustomEvent } from './record';
 
 export { CanvasManager } from './record/observers/canvas/canvas-manager';
 export type { CanvasManagerConstructorOptions } from './record/observers/canvas/canvas-manager';

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -26,7 +26,5 @@ export { record, Replayer, utils, canvasMutation };
 
 export { deserializeArg } from './replay/canvas/deserialize-args';
 
-export { takeFullSnapshot, mirror, freezePage, addCustomEvent } from './record';
-
-export { CanvasManager } from './record/observers/canvas/canvas-manager';
-export type { CanvasManagerConstructorOptions } from './record/observers/canvas/canvas-manager';
+export { CanvasManager, takeFullSnapshot, mirror, freezePage, addCustomEvent } from './record';
+export type { CanvasManagerConstructorOptions } from './record';

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -26,5 +26,11 @@ export { record, Replayer, utils, canvasMutation };
 
 export { deserializeArg } from './replay/canvas/deserialize-args';
 
-export { CanvasManager, takeFullSnapshot, mirror, freezePage, addCustomEvent } from './record';
+export {
+  CanvasManager,
+  takeFullSnapshot,
+  mirror,
+  freezePage,
+  addCustomEvent,
+} from './record';
 export type { CanvasManagerConstructorOptions } from './record';

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -40,6 +40,7 @@ import {
   ShadowDomManagerNoop,
 } from './shadow-dom-manager';
 import {
+  CanvasManager,
   CanvasManagerConstructorOptions,
   CanvasManagerInterface,
   CanvasManagerNoop,
@@ -51,6 +52,7 @@ import {
   registerErrorHandler,
   unregisterErrorHandler,
 } from './error-handler';
+export type {CanvasManagerConstructorOptions} from './observers/canvas/canvas-manager';
 
 function wrapEvent(e: event): eventWithTime {
   const eWithTime = e as eventWithTime;
@@ -753,3 +755,5 @@ function _getCanvasManager(
     return new CanvasManagerNoop();
   }
 }
+
+export {CanvasManager};

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -739,7 +739,9 @@ export default record;
 function _getCanvasManager(
   getCanvasManagerFn:
     | undefined
-    | ((options: Partial<CanvasManagerConstructorOptions>) => CanvasManagerInterface),
+    | ((
+        options: Partial<CanvasManagerConstructorOptions>,
+      ) => CanvasManagerInterface),
   options: CanvasManagerConstructorOptions,
 ) {
   try {

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -52,7 +52,7 @@ import {
   registerErrorHandler,
   unregisterErrorHandler,
 } from './error-handler';
-export type {CanvasManagerConstructorOptions} from './observers/canvas/canvas-manager';
+export type { CanvasManagerConstructorOptions } from './observers/canvas/canvas-manager';
 
 function wrapEvent(e: event): eventWithTime {
   const eWithTime = e as eventWithTime;
@@ -756,4 +756,4 @@ function _getCanvasManager(
   }
 }
 
-export {CanvasManager};
+export { CanvasManager };

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -84,10 +84,7 @@ export type recordOptions<T> = {
   errorHandler?: ErrorHandler;
   onMutation?: (mutations: MutationRecord[]) => boolean;
   getCanvasManager?: (
-    options: Omit<
-      CanvasManagerConstructorOptions,
-      'mutationCb' | 'win' | 'mirror'
-    >,
+    options: CanvasManagerConstructorOptions
   ) => CanvasManagerInterface;
 };
 

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -84,7 +84,7 @@ export type recordOptions<T> = {
   errorHandler?: ErrorHandler;
   onMutation?: (mutations: MutationRecord[]) => boolean;
   getCanvasManager?: (
-    options: CanvasManagerConstructorOptions
+    options: CanvasManagerConstructorOptions,
   ) => CanvasManagerInterface;
 };
 

--- a/packages/rrweb/test/record/cross-origin-iframes.test.ts
+++ b/packages/rrweb/test/record/cross-origin-iframes.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../utils';
 import { unpack } from '../../src/packer/unpack';
 import type * as http from 'http';
-import type { CanvasManagerInterface } from '../../src/record/observers/canvas/canvas-manager';
+import type { CanvasManager } from '../../src/record/observers/canvas/canvas-manager';
 
 interface ISuite {
   code: string;
@@ -35,7 +35,7 @@ interface IWindow extends Window {
     ) => listenerHandler | undefined;
     addCustomEvent<T>(tag: string, payload: T): void;
     pack: (e: eventWithTime) => string;
-    getCanvasManager: () => CanvasManagerInterface;
+    CanvasManager: typeof CanvasManager;
   };
   emit: (e: eventWithTime) => undefined;
   snapshots: eventWithTime[];
@@ -54,12 +54,12 @@ async function injectRecordScript(
   options = options || {};
   await frame.evaluate((options) => {
     (window as unknown as IWindow).snapshots = [];
-    const { record, pack, getCanvasManager } = (window as unknown as IWindow)
+    const { record, pack, CanvasManager } = (window as unknown as IWindow)
       .rrweb;
     const config: recordOptions<eventWithTime> = {
       recordCrossOriginIframes: true,
       recordCanvas: true,
-      getCanvasManager,
+      getCanvasManager: (options) => new CanvasManager(options),
       emit(event) {
         (window as unknown as IWindow).snapshots.push(event);
         (window as unknown as IWindow).emit(event);

--- a/packages/rrweb/test/record/webgl.test.ts
+++ b/packages/rrweb/test/record/webgl.test.ts
@@ -66,10 +66,10 @@ const setup = function (
     ctx.page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
 
     await ctx.page.evaluate((canvasSample) => {
-      const { record, getCanvasManager } = (window as unknown as IWindow).rrweb;
+      const { record, CanvasManager } = (window as unknown as IWindow).rrweb;
       record({
         recordCanvas: true,
-        getCanvasManager,
+        getCanvasManager: (options) => new CanvasManager(options),
         sampling: {
           canvas: canvasSample,
         },

--- a/packages/rrweb/test/record/webgl.test.ts
+++ b/packages/rrweb/test/record/webgl.test.ts
@@ -16,7 +16,7 @@ import {
   waitForRAF,
 } from '../utils';
 import type { ICanvas } from '@sentry-internal/rrweb-snapshot';
-import type { CanvasManagerInterface } from '../../src/record/observers/canvas/canvas-manager';
+import type { CanvasManager } from '../../src/record/observers/canvas/canvas-manager';
 
 interface ISuite {
   code: string;
@@ -31,7 +31,7 @@ interface IWindow extends Window {
       options: recordOptions<eventWithTime>,
     ) => listenerHandler | undefined;
     addCustomEvent<T>(tag: string, payload: T): void;
-    getCanvasManager: () => CanvasManagerInterface;
+    CanvasManager: typeof CanvasManager;
   };
   emit: (e: eventWithTime) => undefined;
 }

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -712,7 +712,7 @@ export function generateRecordSnippet(options: recordOptions<eventWithTime>) {
     inlineImages: ${options.inlineImages},
     plugins: ${options.plugins},
     getCanvasManager: ${
-      options.recordCanvas ? 'rrweb.getCanvasManager' : 'undefined'
+      options.recordCanvas ? '(opts) => new rrweb.CanvasManager(opts)' : 'undefined'
     }
   });
   `;

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -712,7 +712,9 @@ export function generateRecordSnippet(options: recordOptions<eventWithTime>) {
     inlineImages: ${options.inlineImages},
     plugins: ${options.plugins},
     getCanvasManager: ${
-      options.recordCanvas ? '(opts) => new rrweb.CanvasManager(opts)' : 'undefined'
+      options.recordCanvas
+        ? '(opts) => new rrweb.CanvasManager(opts)'
+        : 'undefined'
     }
   });
   `;


### PR DESCRIPTION
This simplifies the code a bit by exporting the CanvasManager directly. With [ReplayCanvas](https://github.com/getsentry/sentry-javascript/pull/10112), we can rely on it for complex setup, but keeps it simple for our users.
