### PR TITLE
fix: Protect against `matches()` being undefined

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -350,17 +350,21 @@ export function createMatchPredicate(
     const el = node as HTMLElement;
     if (el === null) return false;
 
-    if (className) {
-      if (typeof className === 'string') {
-        if (el.matches(`.${className}`)) return true;
-      } else if (elementClassMatchesRegex(el, className)) {
-        return true;
+    try {
+      if (className) {
+        if (typeof className === 'string') {
+          if (el.matches(`.${className}`)) return true;
+        } else if (elementClassMatchesRegex(el, className)) {
+          return true;
+        }
       }
+
+      if (selector && el.matches(selector)) return true;
+
+      return false;
+    } catch {
+      return false;
     }
-
-    if (selector && el.matches(selector)) return true;
-
-    return false;
   };
 }
 


### PR DESCRIPTION
try/catch to protect against cases where `el.matches` is not a function (not sure exact cause, but possibly `el` is undefined, or not an Element type)
