### PR TITLE
feat(replay): Add isManualSnapshot to record

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -101,6 +101,7 @@ function record<T = eventWithTime>(
     sampling = {},
     dataURLOptions = {},
     mousemoveWait,
+    isManualSnapshot,
     recordCanvas = false,
     recordCrossOriginIframes = false,
     recordAfter = options.recordAfter === 'DOMContentLoaded'
@@ -352,6 +353,7 @@ function record<T = eventWithTime>(
             },
           }),
         ),
+      isManualSnapshot,
       recordCanvas,
       blockClass,
       blockSelector,

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -71,6 +71,7 @@ export type recordOptions<T> = {
   packFn?: PackFn;
   sampling?: SamplingStrategy;
   dataURLOptions?: DataURLOptions;
+  isManualSnapshot?: boolean;
   recordCanvas?: boolean;
   recordCrossOriginIframes?: boolean;
   recordAfter?: 'DOMContentLoaded' | 'load';


### PR DESCRIPTION
Add isManualSnapshot to record so the option can be passed in to canvasManager.

Relates to https://github.com/getsentry/team-replay/issues/308