### PR TITLE
feat: Register `errorHandler` inside of CanvasManager

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -813,7 +813,9 @@ function serializeElementNode(
   const len = n.attributes.length;
   for (let i = 0; i < len; i++) {
     const attr = n.attributes[i];
-    if (!ignoreAttribute(tagName, attr.name, attr.value)) {
+    // Looks like `attr.name` can be undefined although the types say differently
+    // see: https://github.com/getsentry/sentry-javascript/issues/10292
+    if (attr.name && !ignoreAttribute(tagName, attr.name, attr.value)) {
       attributes[attr.name] = transformAttribute(
         doc,
         tagName,

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -358,6 +358,7 @@ function record<T = eventWithTime>(
       unblockSelector,
       sampling: sampling['canvas'],
       dataURLOptions,
+      errorHandler,
     },
   );
 

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -20,7 +20,8 @@ import initCanvas2DMutationObserver from './2d';
 import initCanvasContextObserver from './canvas';
 import initCanvasWebGLMutationObserver from './webgl';
 import { getImageBitmapDataUrlWorkerURL } from '@sentry-internal/rrweb-worker';
-import { callbackWrapper } from '../../error-handler';
+import { callbackWrapper, registerErrorHandler } from '../../error-handler';
+import type { ErrorHandler } from '../../../types';
 
 export type RafStamps = { latestId: number; invokeId: number | null };
 
@@ -47,8 +48,9 @@ export interface CanvasManagerConstructorOptions {
   blockSelector: string | null;
   unblockSelector: string | null;
   mirror: Mirror;
-  sampling?: 'all' | number;
   dataURLOptions: DataURLOptions;
+  errorHandler?: ErrorHandler;
+  sampling?: 'all' | number;
 }
 
 export class CanvasManagerNoop implements CanvasManagerInterface {
@@ -113,10 +115,15 @@ export class CanvasManager implements CanvasManagerInterface {
       unblockSelector,
       recordCanvas,
       dataURLOptions,
+      errorHandler,
     } = options;
     this.mutationCb = options.mutationCb;
     this.mirror = options.mirror;
     this.options = options;
+
+    if (errorHandler) {
+      registerErrorHandler(errorHandler);
+    }
 
     if (options.enableManualSnapshot) {
       return;


### PR DESCRIPTION
Needed as we (Sentry), codesplit CanvasManager. Also fixes uncaught exceptions from `createImageBitmap`
