### PR TITLE
fix: Incorrect parsing of functional pseudo class css selector

### DIFF
--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -463,7 +463,7 @@ export function parse(css: string, options: ParserOptions = {}) {
       // parens `)`
       const openingParensCount = (splitSelectors[i].match(/\(/g) || []).length;
 
-      if (openingParensCount > 1) {
+      if (openingParensCount >= 1) {
         // At least one opening parens was found, prepare to look through
         // rest of selectors
         let foundClosingSelector = false;

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -464,7 +464,6 @@ export function parse(css: string, options: ParserOptions = {}) {
       const openingParensCount = (splitSelectors[i].match(/\(/g) || []).length;
       const closingParensCount = (splitSelectors[i].match(/\)/g) || []).length;
       let unbalancedParens = openingParensCount - closingParensCount;
-      console.log(splitSelectors);
 
       if (unbalancedParens >= 1) {
         // At least one opening parens was found, prepare to look through

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -136,7 +136,7 @@ describe('css parser', () => {
       ['.bar:has(div,input:is(:disabled),button:has(:disabled,.baz))'],
     ],
     [
-      '.bar:has(input), .foo:has(input, button), .baz',
+      '.bar:has(input), .foo:has(input, button), .baz {}',
       ['.bar:has(input)', '.foo:has(input, button)', '.baz'],
     ],
     [

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -137,7 +137,7 @@ describe('css parser', () => {
       ],
     ],
     ['.bar((( {}', ['.bar(((']],
-    ['.foo,.bar((( {}', ['.foo', '.bar(((']],
+    ['.foo,.bar(((,.baz {}', ['.foo', '.bar(((', '.baz']],
     [
       '.foo,.bar:has(input:is(:disabled)){color: red;}',
       ['.foo', '.bar:has(input:is(:disabled))'],

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -122,18 +122,18 @@ describe('css parser', () => {
   it.each([
     ['.foo,.bar {}', ['.foo', '.bar']],
     ['.bar:has(:disabled) {}', ['.bar:has(:disabled)']],
-    ['.bar:has(input, button) {}', ['.bar:has(input,button)']],
+    ['.bar:has(input, button) {}', ['.bar:has(input, button)']],
     [
       '.bar:has(input:is(:disabled),button:has(:disabled)) {}',
       ['.bar:has(input:is(:disabled),button:has(:disabled))'],
     ],
     [
       '.bar:has(div, input:is(:disabled), button) {}',
-      ['.bar:has(div, input:is(:disabled), button)'],
+      ['.bar:has(div,input:is(:disabled), button)'],
     ],
     [
       '.bar:has(div, input:is(:disabled),button:has(:disabled,.baz)) {}',
-      ['.bar:has(div, input:is(:disabled),button:has(:disabled,.baz))'],
+      ['.bar:has(div,input:is(:disabled),button:has(:disabled,.baz))'],
     ],
     [
       '.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz)){color: red;}',
@@ -142,6 +142,12 @@ describe('css parser', () => {
       ],
     ],
     ['.bar((( {}', ['.bar(((']],
+    [
+      '.bar:has(:has(:has(a), :has(:has(:has(b, :has(a), c), e))), input:is(:disabled), button) {}',
+      [
+        '.bar:has(:has(:has(a),:has(:has(:has(b,:has(a), c), e))),input:is(:disabled), button)',
+      ],
+    ],
     ['.foo,.bar(((,.baz {}', ['.foo', '.bar(((', '.baz']],
     [
       '.foo,.bar:has(input:is(:disabled)){color: red;}',

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -136,6 +136,10 @@ describe('css parser', () => {
       ['.bar:has(div,input:is(:disabled),button:has(:disabled,.baz))'],
     ],
     [
+      '.bar:has(input), .foo:has(input, button), .baz',
+      ['.bar:has(input)', '.foo:has(input, button)', '.baz'],
+    ],
+    [
       '.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz)){color: red;}',
       [
         '.bar:has(input:is(:disabled),button:has(:disabled,.baz),div:has(:disabled,.baz))',

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -122,10 +122,7 @@ describe('css parser', () => {
   it.each([
     ['.foo,.bar {}', ['.foo', '.bar']],
     ['.bar:has(:disabled) {}', ['.bar:has(:disabled)']],
-    [
-      '.bar:has(input, button) {}',
-      ['.bar:has(input,button)'],
-    ],
+    ['.bar:has(input, button) {}', ['.bar:has(input,button)']],
     [
       '.bar:has(input:is(:disabled),button:has(:disabled)) {}',
       ['.bar:has(input:is(:disabled),button:has(:disabled))'],
@@ -175,9 +172,12 @@ describe('css parser', () => {
     ],
     [
       '.bar:has(input:is(:disabled),.foo,button:is(:disabled)), .foo:has(input, button), .baz,  {}',
-      ['.bar:has(input:is(:disabled),.foo,button:is(:disabled))', '.foo:has(input, button)', '.baz'],
+      [
+        '.bar:has(input:is(:disabled),.foo,button:is(:disabled))',
+        '.foo:has(input, button)',
+        '.baz',
+      ],
     ],
-
   ])(
     'can parse selector(s) with functional pseudo classes: %s',
     (cssText, expected) => {

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -123,12 +123,20 @@ describe('css parser', () => {
     ['.foo,.bar {}', ['.foo', '.bar']],
     ['.bar:has(:disabled) {}', ['.bar:has(:disabled)']],
     [
+      '.bar:has(input, button) {}',
+      ['.bar:has(input,button)'],
+    ],
+    [
       '.bar:has(input:is(:disabled),button:has(:disabled)) {}',
       ['.bar:has(input:is(:disabled),button:has(:disabled))'],
     ],
     [
-      '.bar:has(input:is(:disabled),button:has(:disabled,.baz)) {}',
-      ['.bar:has(input:is(:disabled),button:has(:disabled,.baz))'],
+      '.bar:has(div, input:is(:disabled), button) {}',
+      ['.bar:has(div, input:is(:disabled), button)'],
+    ],
+    [
+      '.bar:has(div, input:is(:disabled),button:has(:disabled,.baz)) {}',
+      ['.bar:has(div, input:is(:disabled),button:has(:disabled,.baz))'],
     ],
     [
       '.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz)){color: red;}',
@@ -165,6 +173,11 @@ describe('css parser', () => {
       '.bar:has(input:is(:disabled),.foo,button:is(:disabled)), .foo {}',
       ['.bar:has(input:is(:disabled),.foo,button:is(:disabled))', '.foo'],
     ],
+    [
+      '.bar:has(input:is(:disabled),.foo,button:is(:disabled)), .foo:has(input, button), .baz,  {}',
+      ['.bar:has(input:is(:disabled),.foo,button:is(:disabled))', '.foo:has(input, button)', '.baz'],
+    ],
+
   ])(
     'can parse selector(s) with functional pseudo classes: %s',
     (cssText, expected) => {

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -119,6 +119,64 @@ describe('css parser', () => {
     expect(out3).toEqual('[data-aa\\:other] { color: red; }');
   });
 
+  it.each([
+    ['.foo,.bar {}', ['.foo', '.bar']],
+    ['.bar:has(:disabled) {}', ['.bar:has(:disabled)']],
+    [
+      '.bar:has(input:is(:disabled),button:has(:disabled)) {}',
+      ['.bar:has(input:is(:disabled),button:has(:disabled))'],
+    ],
+    [
+      '.bar:has(input:is(:disabled),button:has(:disabled,.baz)) {}',
+      ['.bar:has(input:is(:disabled),button:has(:disabled,.baz))'],
+    ],
+    [
+      '.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz)){color: red;}',
+      [
+        '.bar:has(input:is(:disabled),button:has(:disabled,.baz),div:has(:disabled,.baz))',
+      ],
+    ],
+    ['.bar((( {}', ['.bar(((']],
+    ['.foo,.bar((( {}', ['.foo', '.bar(((']],
+    [
+      '.foo,.bar:has(input:is(:disabled)){color: red;}',
+      ['.foo', '.bar:has(input:is(:disabled))'],
+    ],
+    [
+      '.foo,.bar:has(input:is(:disabled),button:has(:disabled,.baz)){color: red;}',
+      ['.foo', '.bar:has(input:is(:disabled),button:has(:disabled,.baz))'],
+    ],
+    [
+      '.foo,.bar:has(input:is(:disabled),button:has(:disabled), div:has(:disabled,.baz)){color: red;}',
+      [
+        '.foo',
+        '.bar:has(input:is(:disabled),button:has(:disabled),div:has(:disabled,.baz))',
+      ],
+    ],
+    [
+      '.foo,.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz)){color: red;}',
+      [
+        '.foo',
+        '.bar:has(input:is(:disabled),button:has(:disabled,.baz),div:has(:disabled,.baz))',
+      ],
+    ],
+    ['.bar:has(:disabled), .foo {}', ['.bar:has(:disabled)', '.foo']],
+    [
+      '.bar:has(input:is(:disabled),.foo,button:is(:disabled)), .foo {}',
+      ['.bar:has(input:is(:disabled),.foo,button:is(:disabled))', '.foo'],
+    ],
+  ])(
+    'can parse selector(s) with functional pseudo classes: %s',
+    (cssText, expected) => {
+      expect(
+        parse(
+          cssText,
+          // @ts-ignore
+        ).stylesheet?.rules[0].selectors,
+      ).toEqual(expected);
+    },
+  );
+
   it('parses imports with quotes correctly', () => {
     const out1 = escapeImportStatement({
       cssText: `@import url("/foo.css;900;800"");`,


### PR DESCRIPTION
This fixes a parsing issue of CSS selectors that use a functional pseudo class with multiple arguments.

For example,

```
.foo:has(button,div) {}
```

Would get parsed as 2 selectors: `.foo:has(button` and `div)` - this results in an invalid stylesheet and looks like the replay is broken.
