### PR TITLE
fix: Change `maxCanvasSize` to be optional

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -47,7 +47,7 @@ export interface CanvasManagerConstructorOptions {
   blockClass: blockClass;
   blockSelector: string | null;
   unblockSelector: string | null;
-  maxCanvasSize: [number, number] | null;
+  maxCanvasSize?: [number, number] | null;
   mirror: Mirror;
   dataURLOptions: DataURLOptions;
   errorHandler?: ErrorHandler;

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -177,7 +177,7 @@ export class CanvasManager implements CanvasManagerInterface {
     blockClass: blockClass,
     blockSelector: string | null,
     unblockSelector: string | null,
-    maxCanvasSize: [number, number] | null,
+    maxCanvasSize: [number, number] | null | undefined,
     options: {
       dataURLOptions: DataURLOptions;
     },
@@ -272,7 +272,7 @@ export class CanvasManager implements CanvasManagerInterface {
     blockClass: blockClass,
     blockSelector: string | null,
     unblockSelector: string | null,
-    maxCanvasSize: [number, number] | null,
+    maxCanvasSize: [number, number] | null | undefined,
     dataURLOptions: DataURLOptions,
     canvasElement?: HTMLCanvasElement,
   ) {


### PR DESCRIPTION
To keep this compatible with prior versions, this option should be optional. This won't affect sentry SDK, but if we want to submit this upstream, it needs to be optional.
