### PR TITLE
fix: fix css parsing in replayer

### DIFF
--- a/.changeset/rotten-spies-enjoy.md
+++ b/.changeset/rotten-spies-enjoy.md
@@ -1,7 +1,0 @@
----
-'rrweb-snapshot': patch
-'rrweb': patch
----
-
-Ensure :hover works on replayer, even if a rule is behind a media query
-Respect the intent behind max-device-width and min-device-width media queries so that their effects are apparent in the replayer context

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -56,11 +56,6 @@ export interface Node {
   };
 }
 
-export interface NodeWithRules extends Node {
-  /** Array of nodes with the types rule, comment and any of the at-rule types. */
-  rules: Array<Rule | Comment | AtRule>;
-}
-
 export interface Rule extends Node {
   /** The list of selectors of the rule, split on commas. Each selector is trimmed from whitespace and comments. */
   selectors?: string[];
@@ -103,11 +98,13 @@ export interface CustomMedia extends Node {
 /**
  * The @document at-rule.
  */
-export interface Document extends NodeWithRules {
+export interface Document extends Node {
   /** The part following @document. */
   document?: string;
   /** The vendor prefix in @document, or undefined if there is none. */
   vendor?: string;
+  /** Array of nodes with the types rule, comment and any of the at-rule types. */
+  rules?: Array<Rule | Comment | AtRule>;
 }
 
 /**
@@ -121,7 +118,10 @@ export interface FontFace extends Node {
 /**
  * The @host at-rule.
  */
-export type Host = NodeWithRules;
+export interface Host extends Node {
+  /** Array of nodes with the types rule, comment and any of the at-rule types. */
+  rules?: Array<Rule | Comment | AtRule>;
+}
 
 /**
  * The @import at-rule.
@@ -153,9 +153,11 @@ export interface KeyFrame extends Node {
 /**
  * The @media at-rule.
  */
-export interface Media extends NodeWithRules {
+export interface Media extends Node {
   /** The part following @media. */
   media?: string;
+  /** Array of nodes with the types rule, comment and any of the at-rule types. */
+  rules?: Array<Rule | Comment | AtRule>;
 }
 
 /**
@@ -179,9 +181,11 @@ export interface Page extends Node {
 /**
  * The @supports at-rule.
  */
-export interface Supports extends NodeWithRules {
+export interface Supports extends Node {
   /** The part following @supports. */
   supports?: string;
+  /** Array of nodes with the types rule, comment and any of the at-rule types. */
+  rules?: Array<Rule | Comment | AtRule>;
 }
 
 /** All at-rules. */
@@ -201,8 +205,10 @@ export type AtRule =
 /**
  * A collection of rules
  */
-export interface StyleRules extends NodeWithRules {
+export interface StyleRules {
   source?: string;
+  /** Array of nodes with the types rule, comment and any of the at-rule types. */
+  rules: Array<Rule | Comment | AtRule>;
   /** Array of Errors. Errors collected during parsing when option silent is true. */
   parsingErrors?: ParserError[];
 }
@@ -218,7 +224,7 @@ export interface Stylesheet extends Node {
 // https://github.com/visionmedia/css-parse/pull/49#issuecomment-30088027
 const commentre = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
 
-export function parse(css: string, options: ParserOptions = {}): Stylesheet {
+export function parse(css: string, options: ParserOptions = {}) {
   /**
    * Positional.
    */
@@ -936,7 +942,7 @@ function trim(str: string) {
  * Adds non-enumerable parent node reference to each node.
  */
 
-function addParent(obj: Stylesheet, parent?: Stylesheet): Stylesheet {
+function addParent(obj: Stylesheet, parent?: Stylesheet) {
   const isNode = obj && typeof obj.type === 'string';
   const childParent = isNode ? obj : parent;
 

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -431,81 +431,104 @@ export function parse(css: string, options: ParserOptions = {}) {
    */
 
   function selector() {
-    whitespace();
-    while (css[0] == '}') {
-      error('extra closing bracket');
-      css = css.slice(1);
-      whitespace();
-    }
+    const m = match(/^([^{]+)/);
 
-    // Use match logic from https://github.com/NxtChg/pieces/blob/3eb39c8287a97632e9347a24f333d52d916bc816/js/css_parser/css_parse.js#L46C1-L47C1
-    const m = match(/^(("(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^{])+)/);
     if (!m) {
       return;
     }
 
     /* @fix Remove all comments from selectors
      * http://ostermiller.org/findcomment.html */
-    const cleanedInput = m[0]
-      .trim()
+    const splitSelectors = trim(m[0])
       .replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '')
-
-      // Handle strings by replacing commas inside them
       .replace(/"(?:\\"|[^"])*"|'(?:\\'|[^'])*'/g, (m) => {
         return m.replace(/,/g, '\u200C');
+      })
+      .split(/\s*(?![^(]*\)),\s*/);
+
+    if (splitSelectors.length <= 1) {
+      return splitSelectors.map((s) => {
+        return s.replace(/\u200C/g, ',');
       });
+    }
 
-    // Split using a custom function and restore commas in strings
-    return customSplit(cleanedInput).map((s) =>
-      s.replace(/\u200C/g, ',').trim(),
-    );
-  }
+    // For each selector, need to check if we properly split on `,`
+    // Example case where selector is:
+    // .bar:has(input:is(:disabled), button:is(:disabled))
+    let i = 0;
+    let j = 0;
+    const len = splitSelectors.length;
+    const finalSelectors = [];
+    while (i < len) {
+      // Look for selectors with opening parens - `(` and search rest of
+      // selectors for the first one with matching number of closing
+      // parens `)`
+      const openingParensCount = (splitSelectors[i].match(/\(/g) || []).length;
+      const closingParensCount = (splitSelectors[i].match(/\)/g) || []).length;
+      let unbalancedParens = openingParensCount - closingParensCount;
 
-  /**
-   * Split selector correctly, ensuring not to split on comma if inside ().
-   */
+      if (unbalancedParens >= 1) {
+        // At least one opening parens was found, prepare to look through
+        // rest of selectors
+        let foundClosingSelector = false;
 
-  function customSplit(input: string) {
-    const result = [];
-    let currentSegment = '';
-    let depthParentheses = 0; // Track depth of parentheses
-    let depthBrackets = 0; // Track depth of square brackets
-    let currentStringChar = null;
+        // Loop starting with next item in array, until we find matching
+        // number of ending parens
+        j = i + 1;
+        while (j < len) {
+          // peek into next item to count the number of closing brackets
+          const nextOpeningParensCount = (splitSelectors[j].match(/\(/g) || [])
+            .length;
+          const nextClosingParensCount = (splitSelectors[j].match(/\)/g) || [])
+            .length;
+          const nextUnbalancedParens =
+            nextClosingParensCount - nextOpeningParensCount;
 
-    for (const char of input) {
-      const hasStringEscape = currentSegment.endsWith('\\');
+          if (nextUnbalancedParens === unbalancedParens) {
+            // Matching # of closing parens was found, join all elements
+            // from i to j
+            finalSelectors.push(splitSelectors.slice(i, j + 1).join(','));
 
-      if (currentStringChar) {
-        if (currentStringChar === char && !hasStringEscape) {
-          currentStringChar = null;
+            // we will want to skip the items that we have joined together
+            i = j + 1;
+
+            // Use to continue the outer loop
+            foundClosingSelector = true;
+
+            // break out of inner loop so we found matching closing parens
+            break;
+          }
+
+          // No matching closing parens found, keep moving through index, but
+          // update the # of unbalanced parents still outstanding
+          j++;
+          unbalancedParens -= nextUnbalancedParens;
         }
-      } else if (char === '(') {
-        depthParentheses++;
-      } else if (char === ')') {
-        depthParentheses--;
-      } else if (char === '[') {
-        depthBrackets++;
-      } else if (char === ']') {
-        depthBrackets--;
-      } else if ('\'"'.includes(char)) {
-        currentStringChar = char;
+
+        if (foundClosingSelector) {
+          // Matching closing selector was found, move to next selector
+          continue;
+        }
+
+        // No matching closing selector was found, either invalid CSS,
+        // or unbalanced number of opening parens were used as CSS
+        // selectors. Assume that rest of the list of selectors are
+        // selectors and break to avoid iterating through the list of
+        // selectors again.
+        splitSelectors
+          .slice(i, len)
+          .forEach((selector) => selector && finalSelectors.push(selector));
+        break;
       }
 
-      // Split point is a comma that is not inside parentheses or square brackets
-      if (char === ',' && depthParentheses === 0 && depthBrackets === 0) {
-        result.push(currentSegment);
-        currentSegment = '';
-      } else {
-        currentSegment += char;
-      }
+      // No opening parens found, contiue looking through list
+      splitSelectors[i] && finalSelectors.push(splitSelectors[i]);
+      i++;
     }
 
-    // Add the last segment
-    if (currentSegment) {
-      result.push(currentSegment);
-    }
-
-    return result;
+    return finalSelectors.map((s) => {
+      return s.replace(/\u200C/g, ',');
+    });
   }
 
   /**

--- a/packages/rrweb-snapshot/src/index.ts
+++ b/packages/rrweb-snapshot/src/index.ts
@@ -13,7 +13,7 @@ import snapshot, {
 } from './snapshot';
 import rebuild, {
   buildNodeWithSN,
-  adaptCssForReplay,
+  addHoverClass,
   createCache,
 } from './rebuild';
 export * from './types';
@@ -24,7 +24,7 @@ export {
   serializeNodeWithId,
   rebuild,
   buildNodeWithSN,
-  adaptCssForReplay,
+  addHoverClass,
   createCache,
   transformAttribute,
   ignoreAttribute,

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -96,7 +96,8 @@ describe('css parser', () => {
     expect(decl.parent).toEqual(rule);
   });
 
-  it('parses { and } in attribute selectors correctly', () => {
+  // TODO(sentry): our parser can't handle this atm
+  it.skip('parses { and } in attribute selectors correctly', () => {
     const result = parse('foo[someAttr~="{someId}"] { color: red; }');
     const rules = result.stylesheet!.rules;
 
@@ -158,27 +159,28 @@ body > ul :is(li:not(:first-of-type) a:hover, li:not(:first-of-type).active a) {
     );
     expect((result.stylesheet!.rules[0] as Rule)!.selectors!.length).toEqual(1);
 
-    const trickresult = parse(
-      `
-li[attr="weirdly("] a:hover, li[attr="weirdly)"] a {
-  background-color: red;
-}
-`,
-    );
-    expect(
-      (trickresult.stylesheet!.rules[0] as Rule)!.selectors!.length,
-    ).toEqual(2);
+    // TODO(sentry): our parser can't handle this atm
+    //     const trickresult = parse(
+    //       `
+    // li[attr="weirdly("] a:hover, li[attr="weirdly)"] a {
+    //   background-color: red;
+    // }
+    // `,
+    //     );
+    //     expect(
+    //       (trickresult.stylesheet!.rules[0] as Rule)!.selectors!.length,
+    //     ).toEqual(2);
 
-    const weirderresult = parse(
-      `
-li[attr="weirder\\"("] a:hover, li[attr="weirder\\")"] a {
-  background-color: red;
-}
-`,
-    );
-    expect(
-      (weirderresult.stylesheet!.rules[0] as Rule)!.selectors!.length,
-    ).toEqual(2);
+    //     const weirderresult = parse(
+    //       `
+    // li[attr="weirder\\"("] a:hover, li[attr="weirder\\")"] a {
+    //   background-color: red;
+    // }
+    // `,
+    //     );
+    //     expect(
+    //       (weirderresult.stylesheet!.rules[0] as Rule)!.selectors!.length,
+    //     ).toEqual(2);
 
     const commainstrresult = parse(
       `
@@ -202,11 +204,11 @@ li[attr="has,comma"] a:hover {
     ],
     [
       '.bar:has(div, input:is(:disabled), button) {}',
-      ['.bar:has(div, input:is(:disabled), button)'],
+      ['.bar:has(div,input:is(:disabled), button)'],
     ],
     [
       '.bar:has(div, input:is(:disabled),button:has(:disabled,.baz)) {}',
-      ['.bar:has(div, input:is(:disabled),button:has(:disabled,.baz))'],
+      ['.bar:has(div,input:is(:disabled),button:has(:disabled,.baz))'],
     ],
     [
       '.bar:has(input), .foo:has(input, button), .baz {}',
@@ -215,13 +217,13 @@ li[attr="has,comma"] a:hover {
     [
       '.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz)){color: red;}',
       [
-        '.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz))',
+        '.bar:has(input:is(:disabled),button:has(:disabled,.baz),div:has(:disabled,.baz))',
       ],
     ],
     [
       '.bar:has(:has(:has(a), :has(:has(:has(b, :has(a), c), e))), input:is(:disabled), button) {}',
       [
-        '.bar:has(:has(:has(a), :has(:has(:has(b, :has(a), c), e))), input:is(:disabled), button)',
+        '.bar:has(:has(:has(a),:has(:has(:has(b,:has(a), c), e))),input:is(:disabled), button)',
       ],
     ],
     [
@@ -236,14 +238,14 @@ li[attr="has,comma"] a:hover {
       '.foo,.bar:has(input:is(:disabled),button:has(:disabled), div:has(:disabled,.baz)){color: red;}',
       [
         '.foo',
-        '.bar:has(input:is(:disabled),button:has(:disabled), div:has(:disabled,.baz))',
+        '.bar:has(input:is(:disabled),button:has(:disabled),div:has(:disabled,.baz))',
       ],
     ],
     [
       '.foo,.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz)){color: red;}',
       [
         '.foo',
-        '.bar:has(input:is(:disabled),button:has(:disabled,.baz), div:has(:disabled,.baz))',
+        '.bar:has(input:is(:disabled),button:has(:disabled,.baz),div:has(:disabled,.baz))',
       ],
     ],
     ['.bar:has(:disabled), .foo {}', ['.bar:has(:disabled)', '.foo']],

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -3,11 +3,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import {
-  adaptCssForReplay,
-  buildNodeWithSN,
-  createCache,
-} from '../src/rebuild';
+import { addHoverClass, buildNodeWithSN, createCache } from '../src/rebuild';
 import { NodeType } from '../src/types';
 import { createMirror, Mirror } from '../src/utils';
 
@@ -111,90 +107,47 @@ describe('rebuild', function () {
   describe('add hover class to hover selector related rules', function () {
     it('will do nothing to css text without :hover', () => {
       const cssText = 'body { color: white }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(cssText);
+      expect(addHoverClass(cssText, cache)).toEqual(cssText);
     });
 
     it('can add hover class to css text', () => {
       const cssText = '.a:hover { color: white }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
+      expect(addHoverClass(cssText, cache)).toEqual(
         '.a:hover, .a.\\:hover { color: white }',
-      );
-    });
-
-    it('can correctly add hover when in middle of selector', () => {
-      const cssText = 'ul li a:hover img { color: white }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
-        'ul li a:hover img, ul li a.\\:hover img { color: white }',
-      );
-    });
-
-    it('can correctly add hover on multiline selector', () => {
-      const cssText = `ul li.specified a:hover img,
-ul li.multiline
-b:hover
-img,
-ul li.specified c:hover img {
-  color: white
-}`;
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
-        `ul li.specified a:hover img, ul li.specified a.\\:hover img,
-ul li.multiline
-b:hover
-img, ul li.multiline
-b.\\:hover
-img,
-ul li.specified c:hover img, ul li.specified c.\\:hover img {
-  color: white
-}`,
-      );
-    });
-
-    it('can add hover class within media query', () => {
-      const cssText = '@media screen { .m:hover { color: white } }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
-        '@media screen { .m:hover, .m.\\:hover { color: white } }',
       );
     });
 
     it('can add hover class when there is multi selector', () => {
       const cssText = '.a, .b:hover, .c { color: white }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
+      expect(addHoverClass(cssText, cache)).toEqual(
         '.a, .b:hover, .b.\\:hover, .c { color: white }',
       );
     });
 
     it('can add hover class when there is a multi selector with the same prefix', () => {
       const cssText = '.a:hover, .a:hover::after { color: white }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
+      expect(addHoverClass(cssText, cache)).toEqual(
         '.a:hover, .a.\\:hover, .a:hover::after, .a.\\:hover::after { color: white }',
       );
     });
 
     it('can add hover class when :hover is not the end of selector', () => {
       const cssText = 'div:hover::after { color: white }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
+      expect(addHoverClass(cssText, cache)).toEqual(
         'div:hover::after, div.\\:hover::after { color: white }',
       );
     });
 
     it('can add hover class when the selector has multi :hover', () => {
       const cssText = 'a:hover b:hover { color: white }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
+      expect(addHoverClass(cssText, cache)).toEqual(
         'a:hover b:hover, a.\\:hover b.\\:hover { color: white }',
       );
     });
 
     it('will ignore :hover in css value', () => {
       const cssText = '.a::after { content: ":hover" }';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(cssText);
-    });
-
-    it('can adapt media rules to replay context', () => {
-      const cssText =
-        '@media only screen and (min-device-width : 1200px) { .a { width: 10px; }}';
-      expect(adaptCssForReplay(cssText, cache)).toEqual(
-        '@media only screen and (min-width : 1200px) { .a { width: 10px; }}',
-      );
+      expect(addHoverClass(cssText, cache)).toEqual(cssText);
     });
 
     // this benchmark is unreliable when run in parallel with other tests
@@ -204,7 +157,7 @@ ul li.specified c:hover img, ul li.specified c.\\:hover img {
         'utf8',
       );
       const start = process.hrtime();
-      adaptCssForReplay(cssText, cache);
+      addHoverClass(cssText, cache);
       const end = process.hrtime(start);
       const duration = getDuration(end);
       expect(duration).toBeLessThan(100);
@@ -219,11 +172,11 @@ ul li.specified c:hover img, ul li.specified c.\\:hover img {
       );
 
       const start = process.hrtime();
-      adaptCssForReplay(cssText, cache);
+      addHoverClass(cssText, cache);
       const end = process.hrtime(start);
 
       const cachedStart = process.hrtime();
-      adaptCssForReplay(cssText, cache);
+      addHoverClass(cssText, cache);
       const cachedEnd = process.hrtime(cachedStart);
 
       expect(getDuration(cachedEnd) * factor).toBeLessThan(getDuration(end));


### PR DESCRIPTION
This reverts https://github.com/getsentry/rrweb/pull/182 (i.e. we are going back to https://github.com/getsentry/rrweb/pull/169) as we had some performance regressions with the CSS changes.

I tested these against the replays that had crashed with the upstream changes and they seem to work ok.