### PR TITLE
fix(rrweb): allow for drawing multiple mousetails

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -491,13 +491,13 @@ export class Replayer {
     }
     if (typeof config.mouseTail !== 'undefined') {
       if (config.mouseTail === false) {
-        for (const [, { mouseTail }] of Object.entries(this.pointers)) {
+        for (const { mouseTail } of Object.values(this.pointers)) {
           if (mouseTail) {
             mouseTail.style.display = 'none';
           }
         }
       } else {
-        for (let [, { mouseTail }] of Object.entries(this.pointers)) {
+        for (let { mouseTail } of Object.values(this.pointers)) {
           if (!mouseTail) {
             mouseTail = document.createElement('canvas');
             mouseTail.width = Number.parseFloat(this.iframe.width);

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2176,7 +2176,7 @@ export class Replayer {
       if (!ctx || !pointer.tailPositions.length) {
         return;
       }
-      ctx.clearRect(0, 0, this.mouseTail.width, this.mouseTail.height);
+      ctx.clearRect(0, 0, position.x, position.y);
       ctx.beginPath();
       ctx.lineWidth = lineWidth;
       ctx.lineCap = lineCap;

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -652,9 +652,9 @@ export class Replayer {
     this.iframe.style.display = 'inherit';
 
     for (const el of [
-      Object.values(this.pointers).flatMap((a) => a.mouseTail),
+      ...Object.values(this.pointers).flatMap((a) => a.mouseTail),
       this.iframe,
-    ].flat()) {
+    ]) {
       if (!el) {
         continue;
       }

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -442,11 +442,8 @@ export class Replayer {
     mouseTail.height = Number.parseFloat(this.iframe.height);
     this.wrapper.insertBefore(mouseTail, this.iframe);
 
-    if (this.config.mouseTail === false) {
-      mouseTail.style.display = 'none';
-    } else {
-      mouseTail.style.display = 'inherit';
-    }
+    mouseTail.style.display =
+      this.config.mouseTail === false ? 'none' : 'inherit';
 
     const newMouse = document.createElement('div');
     newMouse.classList.add('replayer-mouse');
@@ -455,7 +452,7 @@ export class Replayer {
       pointerEl: newMouse,
       tailPositions: [],
       pointerPosition: null,
-      mouseTail: mouseTail,
+      mouseTail,
     };
 
     if (indicatesTouchDevice(event)) {
@@ -655,9 +652,7 @@ export class Replayer {
     this.iframe.style.display = 'inherit';
 
     for (const el of [
-      Object.values(this.pointers)
-        .map((a) => a.mouseTail)
-        .flat(),
+      Object.values(this.pointers).flatMap((a) => a.mouseTail),
       this.iframe,
     ].flat()) {
       if (!el) {

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -438,7 +438,9 @@ export class Replayer {
   private createPointer(pointerId: number, event: eventWithTime) {
     const mouseTail = document.createElement('canvas');
     mouseTail.classList.add('replayer-mouse-tail');
-    this.wrapper.appendChild(mouseTail);
+    mouseTail.width = Number.parseFloat(this.iframe.width);
+    mouseTail.height = Number.parseFloat(this.iframe.height);
+    this.wrapper.insertBefore(mouseTail, this.iframe);
 
     if (this.config.mouseTail === false) {
       mouseTail.style.display = 'none';
@@ -655,6 +657,19 @@ export class Replayer {
 
   private handleResize = (dimension: viewportResizeDimension) => {
     this.iframe.style.display = 'inherit';
+
+    for (const el of [
+      Object.values(this.pointers)
+        .map((a) => a.mouseTail)
+        .flat(),
+      this.iframe,
+    ].flat()) {
+      if (!el) {
+        continue;
+      }
+      el.setAttribute('width', String(dimension.width));
+      el.setAttribute('height', String(dimension.height));
+    }
 
     for (const [, { mouseTail }] of Object.entries(this.pointers)) {
       for (const el of [mouseTail, this.iframe]) {

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1222,6 +1222,9 @@ export class Replayer {
               } else if (d.type === MouseInteractions.TouchEnd) {
                 pointer.touchActive = false;
                 pointer.pointerEl.remove();
+                if (pointer.mouseTail) {
+                  pointer.mouseTail.remove();
+                }
                 delete this.pointers[pointerId];
               }
               if (d.type === MouseInteractions.MouseDown) {
@@ -1258,6 +1261,9 @@ export class Replayer {
                 pointer.pointerEl.classList.add('touch-active');
               } else if (d.type === MouseInteractions.TouchEnd) {
                 pointer.pointerEl.remove();
+                if (pointer.mouseTail) {
+                  pointer.mouseTail.remove();
+                }
                 delete this.pointers[pointerId];
               } else {
                 // for MouseDown & MouseUp also invoke default behavior

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -140,8 +140,6 @@ export class Replayer {
   public usingVirtualDom = false;
   public virtualDom: RRDocument = new RRDocument();
 
-  private mouseTail: HTMLCanvasElement | null = null;
-
   private emitter: Emitter = mitt();
 
   private nextUserInteractionEvent: eventWithTime | null;
@@ -171,6 +169,7 @@ export class Replayer {
       pointerEl: HTMLDivElement;
       tailPositions: Array<{ x: number; y: number }>;
       pointerPosition: mouseMovePos | null;
+      mouseTail: HTMLCanvasElement | null;
     }
   > = {};
   private lastMouseDownEvent: [Node, Event] | null = null;
@@ -437,6 +436,18 @@ export class Replayer {
   }
 
   private createPointer(pointerId: number, event: eventWithTime) {
+    const mouseTail = document.createElement('canvas');
+    mouseTail.width = Number.parseFloat(this.iframe.width);
+    mouseTail.height = Number.parseFloat(this.iframe.height);
+    mouseTail.classList.add('replayer-mouse-tail');
+    this.wrapper.insertBefore(mouseTail, this.iframe);
+
+    if (this.config.mouseTail === false) {
+      mouseTail.style.display = 'none';
+    } else {
+      mouseTail.style.display = 'inherit';
+    }
+
     const newMouse = document.createElement('div');
     newMouse.classList.add('replayer-mouse');
     this.pointers[pointerId] = {
@@ -444,7 +455,9 @@ export class Replayer {
       pointerEl: newMouse,
       tailPositions: [],
       pointerPosition: null,
+      mouseTail: mouseTail,
     };
+
     if (indicatesTouchDevice(event)) {
       newMouse.classList.add('touch-device');
     }
@@ -481,18 +494,22 @@ export class Replayer {
     }
     if (typeof config.mouseTail !== 'undefined') {
       if (config.mouseTail === false) {
-        if (this.mouseTail) {
-          this.mouseTail.style.display = 'none';
+        for (const [, { mouseTail }] of Object.entries(this.pointers)) {
+          if (mouseTail) {
+            mouseTail.style.display = 'none';
+          }
         }
       } else {
-        if (!this.mouseTail) {
-          this.mouseTail = document.createElement('canvas');
-          this.mouseTail.width = Number.parseFloat(this.iframe.width);
-          this.mouseTail.height = Number.parseFloat(this.iframe.height);
-          this.mouseTail.classList.add('replayer-mouse-tail');
-          this.wrapper.insertBefore(this.mouseTail, this.iframe);
+        for (let [, { mouseTail }] of Object.entries(this.pointers)) {
+          if (!mouseTail) {
+            mouseTail = document.createElement('canvas');
+            mouseTail.width = Number.parseFloat(this.iframe.width);
+            mouseTail.height = Number.parseFloat(this.iframe.height);
+            mouseTail.classList.add('replayer-mouse-tail');
+            this.wrapper.insertBefore(mouseTail, this.iframe);
+          }
+          mouseTail.style.display = 'inherit';
         }
-        this.mouseTail.style.display = 'inherit';
       }
     }
   }
@@ -614,13 +631,6 @@ export class Replayer {
     this.wrapper.classList.add('replayer-wrapper');
     this.config.root.appendChild(this.wrapper);
 
-    if (this.config.mouseTail !== false) {
-      this.mouseTail = document.createElement('canvas');
-      this.mouseTail.classList.add('replayer-mouse-tail');
-      this.mouseTail.style.display = 'inherit';
-      this.wrapper.appendChild(this.mouseTail);
-    }
-
     this.iframe = document.createElement('iframe');
     const attributes = ['allow-same-origin'];
     if (this.config.UNSAFE_replayCanvas) {
@@ -643,12 +653,15 @@ export class Replayer {
 
   private handleResize = (dimension: viewportResizeDimension) => {
     this.iframe.style.display = 'inherit';
-    for (const el of [this.mouseTail, this.iframe]) {
-      if (!el) {
-        continue;
+
+    for (const [, { mouseTail }] of Object.entries(this.pointers)) {
+      for (const el of [mouseTail, this.iframe]) {
+        if (!el) {
+          continue;
+        }
+        el.setAttribute('width', String(dimension.width));
+        el.setAttribute('height', String(dimension.height));
       }
-      el.setAttribute('width', String(dimension.width));
-      el.setAttribute('height', String(dimension.height));
     }
   };
 
@@ -2157,7 +2170,9 @@ export class Replayer {
   }
 
   private drawMouseTail(position: { x: number; y: number }, pointerId: number) {
-    if (!this.mouseTail) {
+    const pointer = this.pointers[pointerId];
+
+    if (!pointer.mouseTail) {
       return;
     }
 
@@ -2166,17 +2181,17 @@ export class Replayer {
         ? defaultMouseTailConfig
         : Object.assign({}, defaultMouseTailConfig, this.config.mouseTail);
 
-    const pointer = this.pointers[pointerId];
-
     const draw = () => {
-      if (!this.mouseTail) {
+      if (!pointer.mouseTail) {
         return;
       }
-      const ctx = this.mouseTail.getContext('2d');
+      const mouseTail = pointer.mouseTail;
+
+      const ctx = mouseTail.getContext('2d');
       if (!ctx || !pointer.tailPositions.length) {
         return;
       }
-      ctx.clearRect(0, 0, position.x, position.y);
+      ctx.clearRect(0, 0, mouseTail.width, mouseTail.height);
       ctx.beginPath();
       ctx.lineWidth = lineWidth;
       ctx.lineCap = lineCap;

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -500,19 +500,15 @@ export class Replayer {
           }
         }
       } else {
-        for (const [pointerId, { mouseTail }] of Object.entries(
-          this.pointers,
-        )) {
-          const id = parseInt(pointerId);
-          const tail = document.createElement('canvas');
+        for (let [, { mouseTail }] of Object.entries(this.pointers)) {
           if (!mouseTail) {
-            tail.width = Number.parseFloat(this.iframe.width);
-            tail.height = Number.parseFloat(this.iframe.height);
-            tail.classList.add('replayer-mouse-tail');
-            this.wrapper.insertBefore(tail, this.iframe);
-            this.pointers[id].mouseTail = tail;
+            mouseTail = document.createElement('canvas');
+            mouseTail.width = Number.parseFloat(this.iframe.width);
+            mouseTail.height = Number.parseFloat(this.iframe.height);
+            mouseTail.classList.add('replayer-mouse-tail');
+            this.wrapper.insertBefore(mouseTail, this.iframe);
           }
-          tail.style.display = 'inherit';
+          mouseTail.style.display = 'inherit';
         }
       }
     }
@@ -669,16 +665,6 @@ export class Replayer {
       }
       el.setAttribute('width', String(dimension.width));
       el.setAttribute('height', String(dimension.height));
-    }
-
-    for (const [, { mouseTail }] of Object.entries(this.pointers)) {
-      for (const el of [mouseTail, this.iframe]) {
-        if (!el) {
-          continue;
-        }
-        el.setAttribute('width', String(dimension.width));
-        el.setAttribute('height', String(dimension.height));
-      }
     }
   };
 

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -437,10 +437,8 @@ export class Replayer {
 
   private createPointer(pointerId: number, event: eventWithTime) {
     const mouseTail = document.createElement('canvas');
-    mouseTail.width = Number.parseFloat(this.iframe.width);
-    mouseTail.height = Number.parseFloat(this.iframe.height);
     mouseTail.classList.add('replayer-mouse-tail');
-    this.wrapper.insertBefore(mouseTail, this.iframe);
+    this.wrapper.appendChild(mouseTail);
 
     if (this.config.mouseTail === false) {
       mouseTail.style.display = 'none';
@@ -500,15 +498,19 @@ export class Replayer {
           }
         }
       } else {
-        for (let [, { mouseTail }] of Object.entries(this.pointers)) {
+        for (const [pointerId, { mouseTail }] of Object.entries(
+          this.pointers,
+        )) {
+          const id = parseInt(pointerId);
+          const tail = document.createElement('canvas');
           if (!mouseTail) {
-            mouseTail = document.createElement('canvas');
-            mouseTail.width = Number.parseFloat(this.iframe.width);
-            mouseTail.height = Number.parseFloat(this.iframe.height);
-            mouseTail.classList.add('replayer-mouse-tail');
-            this.wrapper.insertBefore(mouseTail, this.iframe);
+            tail.width = Number.parseFloat(this.iframe.width);
+            tail.height = Number.parseFloat(this.iframe.height);
+            tail.classList.add('replayer-mouse-tail');
+            this.wrapper.insertBefore(tail, this.iframe);
+            this.pointers[id].mouseTail = tail;
           }
-          mouseTail.style.display = 'inherit';
+          tail.style.display = 'inherit';
         }
       }
     }

--- a/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/replayer.test.ts.snap
@@ -8,13 +8,7 @@ exports[`replayer can fast forward past StyleSheetRule changes on virtual elemen
   </head>
   <body>
     <div class=\\"replayer-wrapper\\">
-      <canvas
-        class=\\"replayer-mouse-tail\\"
-        width=\\"1000\\"
-        height=\\"800\\"
-        style=\\"display: inherit\\"
-      ></canvas
-      ><iframe
+      <iframe
         sandbox=\\"allow-same-origin\\"
         scrolling=\\"no\\"
         width=\\"1000\\"
@@ -87,13 +81,7 @@ exports[`replayer can fast forward past StyleSheetRule deletion on virtual eleme
   </head>
   <body>
     <div class=\\"replayer-wrapper\\">
-      <canvas
-        class=\\"replayer-mouse-tail\\"
-        width=\\"1000\\"
-        height=\\"800\\"
-        style=\\"display: inherit\\"
-      ></canvas
-      ><iframe
+      <iframe
         sandbox=\\"allow-same-origin\\"
         scrolling=\\"no\\"
         width=\\"1000\\"
@@ -164,13 +152,7 @@ exports[`replayer can handle removing style elements 1`] = `
   </head>
   <body>
     <div class=\\"replayer-wrapper\\">
-      <canvas
-        class=\\"replayer-mouse-tail\\"
-        width=\\"1000\\"
-        height=\\"800\\"
-        style=\\"display: inherit\\"
-      ></canvas
-      ><iframe
+      <iframe
         sandbox=\\"allow-same-origin\\"
         scrolling=\\"no\\"
         width=\\"1000\\"
@@ -211,13 +193,7 @@ exports[`replayer replays same timestamp events in correct order (with addAction
   </head>
   <body>
     <div class=\\"replayer-wrapper\\">
-      <canvas
-        class=\\"replayer-mouse-tail\\"
-        width=\\"1000\\"
-        height=\\"800\\"
-        style=\\"display: inherit\\"
-      ></canvas
-      ><iframe
+      <iframe
         sandbox=\\"allow-same-origin\\"
         scrolling=\\"no\\"
         width=\\"1000\\"
@@ -261,13 +237,7 @@ exports[`replayer replays same timestamp events in correct order 1`] = `
   </head>
   <body>
     <div class=\\"replayer-wrapper\\">
-      <canvas
-        class=\\"replayer-mouse-tail\\"
-        width=\\"1000\\"
-        height=\\"800\\"
-        style=\\"display: inherit\\"
-      ></canvas
-      ><iframe
+      <iframe
         sandbox=\\"allow-same-origin\\"
         scrolling=\\"no\\"
         width=\\"1000\\"

--- a/packages/rrweb/test/replayer.test.ts
+++ b/packages/rrweb/test/replayer.test.ts
@@ -821,6 +821,12 @@ describe('replayer', function () {
         () => document.querySelectorAll('.replayer-mouse')!.length,
       ),
     ).toEqual(0);
+
+    expect(
+      await page.evaluate(
+        () => document.querySelectorAll('.replayer-mouse-tail')!.length,
+      ),
+    ).toEqual(0);
   });
 
   // This should't happen, but we want to test/capture the behavior
@@ -857,6 +863,12 @@ describe('replayer', function () {
     expect(
       await page.evaluate(
         () => document.querySelectorAll('.replayer-mouse')!.length,
+      ),
+    ).toEqual(0);
+
+    expect(
+      await page.evaluate(
+        () => document.querySelectorAll('.replayer-mouse-tail')!.length,
       ),
     ).toEqual(0);
   });


### PR DESCRIPTION
this change allows us to draw multiple "mousetails" at once.


ios replay BEFORE: only one tail showing up

https://github.com/getsentry/rrweb/assets/56095982/05b5bc8a-b600-4a34-929f-fb9fcc4acd5f


ios replay AFTER: both tails showing up & clearing properly:

https://github.com/getsentry/rrweb/assets/56095982/99f74e19-b1e6-402e-a766-ce0d22a0851b








