### PR TITLE
fix(ts): Forgot to include 3.8 typings dirs in `files`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ dist
 # `.yarn/install-state.gz` is an optimization file that you shouldn't ever have to commit. 
 # It simply stores the exact state of your project so that the next commands can boot without having to resolve your workspaces all over again.
 .yarn/install-state.gz
+
+typings
+typings-ts3.8
+dist-ts3.8

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -41,7 +41,8 @@
     "dist",
     "lib",
     "es",
-    "typings"
+    "typings",
+    "typings-ts3.8"
   ],
   "author": "yanzhen@smartx.com",
   "license": "MIT",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -48,7 +48,8 @@
   },
   "files": [
     "build",
-    "dist"
+    "dist",
+    "dist-ts3.8"
   ],
   "devDependencies": {
     "vite": "^3.2.0-beta.2",


### PR DESCRIPTION
This is needed to include the downleveled typings in our dist package.
