### PR TITLE
feat(snapshot): Use unpatched `setTimeout` and `clearTimeout`

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -27,6 +27,8 @@ import {
   extractFileExtension,
   toUpperCase,
   shouldMaskInput,
+  setTimeout,
+  clearTimeout,
 } from './utils';
 
 let _id = 1;


### PR DESCRIPTION
Use unpatched `setTimeout` and `clearTimeout` to ensure that we are not triggering Angular change detection when snapshotting.
