### PR TITLE
feat(snapshot): Check "blocked" status of iframes before accessing `contentDocument`

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1019,7 +1019,9 @@ function serializeElementNode(
   }
   // iframe
   if (tagName === 'iframe' && !keepIframeSrcFn(attributes.src as string)) {
-    if (!(n as HTMLIFrameElement).contentDocument) {
+    // Don't try to access `contentDocument` if iframe is blocked, otherwise it
+    // will trigger browser warnings.
+    if (!needBlock && !(n as HTMLIFrameElement).contentDocument) {
       // we can't record it directly as we can't see into it
       // preserve the src attribute so a decision can be taken at replay time
       attributes.rr_src = attributes.src;

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -237,6 +237,56 @@ describe('style elements', () => {
   });
 });
 
+describe('iframe', () => {
+  const serializeNode = (node: Node): serializedNodeWithId | null => {
+    return serializeNodeWithId(node, {
+      doc: document,
+      mirror: new Mirror(),
+      blockClass: 'blockblock',
+      blockSelector: null,
+      unblockSelector: null,
+      maskAllText: false,
+      maskTextClass: 'maskmask',
+      unmaskTextClass: null,
+      maskTextSelector: null,
+      unmaskTextSelector: null,
+      skipChild: false,
+      inlineStylesheet: true,
+      maskAttributeFn: undefined,
+      maskTextFn: undefined,
+      maskInputFn: undefined,
+      slimDOMOptions: {},
+      newlyAddedElement: false,
+    });
+  };
+
+  const render = (html: string): HTMLDivElement => {
+    document.write(html);
+    return document.querySelector('iframe')!;
+  };
+
+  it('serializes', () => {
+    // Not sure how to trigger condition where we can't access
+    // `iframe.contentDocument` due to CORS. Ideally it should have `rr_src`
+    // attribute
+    const el = render(`<iframe src="https://example.dev"/>`);
+    expect(serializeNode(el)).toMatchObject({
+      attributes: {},
+    });
+  });
+
+  it('can be blocked', () => {
+    const el = render(`<iframe class="blockblock" src="https://example.dev"/>`);
+    expect(serializeNode(el)).toMatchObject({
+      attributes: {
+        class: 'blockblock',
+        rr_height: '0px',
+        rr_width: '0px',
+      },
+    });
+  });
+});
+
 describe('scrollTop/scrollLeft', () => {
   const serializeNode = (node: Node): serializedNodeWithId | null => {
     return serializeNodeWithId(node, {


### PR DESCRIPTION
Do not attempt to access `contentDocument` of iframe if element is blocked, otherwise it will trigger a browser warning. e.g.

`Blocked a frame with origin "<foo>" from accessing a frame with origin "<bar>". Protocols, domains, and ports must match.`

Fixes https://github.com/getsentry/sentry-javascript/issues/6560
