### PR TITLE
fix(rrweb): null check for pointerEl

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -2165,8 +2165,11 @@ export class Replayer {
     const _y = y * base.absoluteScale + base.y;
 
     const pointer = this.pointers[pointerId];
-    pointer.pointerEl.style.left = `${_x}px`;
-    pointer.pointerEl.style.top = `${_y}px`;
+    if (pointer.pointerEl) {
+      pointer.pointerEl.style.left = `${_x}px`;
+      pointer.pointerEl.style.top = `${_y}px`;
+    }
+
     if (!isSync) {
       this.drawMouseTail({ x: _x, y: _y }, pointerId);
     }


### PR DESCRIPTION
fixes [JAVASCRIPT-2THH](https://sentry.sentry.io/issues/5473658404/)

we remove the `pointerEl` when a `TouchEnd` event occurs, so we need to do a null check to make sure it exists before trying to access its properties.