### PR TITLE
fix(canvas): Fix missing `addWindow` call when `enableManualSnapshot==true`

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -173,6 +173,7 @@ export class CanvasManager implements CanvasManagerInterface {
     ) {
       this.worker = this.initFPSWorker();
     }
+    this.addWindow(win);
     if (options.enableManualSnapshot) {
       return;
     }
@@ -194,7 +195,6 @@ export class CanvasManager implements CanvasManagerInterface {
         );
       }
     })();
-    this.addWindow(win);
   }
 
   public addWindow(win: IWindow) {


### PR DESCRIPTION
Need to move this up so window is added in the case where we have manual snapshots.
