### PR TITLE
fix: Missed downlevel-dts dep in types, update git sha

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -52,13 +52,13 @@
     "dist-ts3.8"
   ],
   "devDependencies": {
+    "downlevel-dts": "https://github.com/getsentry/downlevel-dts",
     "vite": "^3.2.0-beta.2",
     "vite-plugin-dts": "^1.7.3"
   },
   "dependencies": {
     "@sentry-internal/rrweb-snapshot": "2.21.0",
-    "@types/css-font-loading-module": "0.0.7",
-    "downlevel-dts": "https://github.com/getsentry/downlevel-dts"
+    "@types/css-font-loading-module": "0.0.7"
   },
   "browserslist": [
     "supports es6-class"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5897,7 +5897,7 @@ dotenv@~10.0.0:
 
 "downlevel-dts@https://github.com/getsentry/downlevel-dts":
   version "0.11.0"
-  resolved "https://github.com/getsentry/downlevel-dts#6e5cc7146f0bdd684d3a77ed184e0548e5e7d2a8"
+  resolved "https://github.com/getsentry/downlevel-dts#26342728379689259f494d79053272c6f2f0ea14"
   dependencies:
     semver "^7.3.2"
     shelljs "^0.8.3"


### PR DESCRIPTION
Use latest git sha of downlevel-dts
