### PR TITLE
fix: manual snapshot in rAF loop

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -511,7 +511,10 @@ export class CanvasManager implements CanvasManagerInterface {
             })();
           });
       });
-      rafId = onRequestAnimationFrame(takeCanvasSnapshots);
+
+      if (!isManualSnapshot) {
+        rafId = onRequestAnimationFrame(takeCanvasSnapshots);
+      }
     };
 
     rafId = onRequestAnimationFrame(takeCanvasSnapshots);


### PR DESCRIPTION
## Background

I followed [Set Up Session Replay | Sentry for Javascript](https://docs.sentry.io/platforms/javascript/session-replay/#3d-and-webgl-canvases) and got CPU high usage. 

![CleanShot-2024-07-10-at-15 22 35@2x](https://github.com/getsentry/rrweb/assets/1590707/c20f51de-716f-43b5-a1f2-6ce4fab4d9d3)


## Solution

The takeCanvasSnapshots should not be in rAF loop when the `isManualSnapshot` is true. I also checked the [rrweb/packages/rrweb/src/record/observers/canvas/canvas-manager.ts at master · rrweb-io/rrweb](https://github.com/rrweb-io/rrweb/blob/master/packages/rrweb/src/record/observers/canvas/canvas-manager.ts#L172) and confirmed it's Sentry customized logic.