### PR TITLE
fix: Set style properties directly in mutation

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -34,6 +34,7 @@ import {
   inDom,
   getShadowHost,
   closestElementOfNode,
+  splitStyleAttributes,
 } from '../utils';
 
 type DoubleLinkedListNode = {
@@ -659,7 +660,16 @@ export default class MutationBuffer {
             }
             const old = this.unattachedDoc.createElement('span');
             if (m.oldValue) {
-              old.setAttribute('style', m.oldValue);
+              console.log('yalc version 3');
+              // Split the style string into individual style rules
+              const styleAttributes = splitStyleAttributes(m.oldValue);
+
+              // set each style property individually to avoid csp error
+              styleAttributes.forEach(({ property, value }) => {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-expect-error
+                old.style[property] = value;
+              });
             }
             for (const pname of Array.from(target.style)) {
               const newValue = target.style.getPropertyValue(pname);

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -670,3 +670,28 @@ export function clearTimeout(
 ): ReturnType<typeof window.clearTimeout> {
   return getImplementation('clearTimeout')(...rest);
 }
+
+/**
+ * Takes a styles attribute string and converts it to key value pairs
+ * @param styles - The full stype attributes string
+ *
+ */
+export function splitStyleAttributes(styles: string) {
+  const splitStyles = styles.split(';');
+  return splitStyles
+    .filter((value) => value.split(':').length == 2)
+    .map((style) => {
+      let [property, value] = style.trim().split(':');
+
+      property = property.trim();
+      value = value.trim();
+
+      // Convert kebab-case to camelCase
+      const camelCasedProperty = property.replace(
+        /-([a-z])/g,
+        (match, letter: string) => letter.toUpperCase(),
+      );
+
+      return { property: camelCasedProperty, value };
+    });
+}

--- a/packages/rrweb/test/util.test.ts
+++ b/packages/rrweb/test/util.test.ts
@@ -7,6 +7,7 @@ import {
   inDom,
   shadowHostInDom,
   getShadowHost,
+  splitStyleAttributes,
 } from '../src/utils';
 
 describe('Utilities for other modules', () => {
@@ -141,6 +142,19 @@ describe('Utilities for other modules', () => {
       expect(getRootShadowHost(a.childNodes[0])).toBe(a.childNodes[0]);
       expect(shadowHostInDom(a.childNodes[0])).toBeTruthy();
       expect(inDom(a.childNodes[0])).toBeTruthy();
+    });
+
+    it('should split styles attributes', () => {
+      const styleAttribute =
+        'background-color: peachpuff; padding: 20px; margin-top: 0;';
+
+      const splitStyles = splitStyleAttributes(styleAttribute);
+
+      expect(splitStyles).toEqual([
+        { property: 'backgroundColor', value: 'peachpuff' },
+        { property: 'padding', value: '20px' },
+        { property: 'marginTop', value: '0' },
+      ]);
     });
   });
 });


### PR DESCRIPTION
This PR sets style attributes directly instead of rewriting the full `style` attribute. That avoids users running into runtime CSP errors when they have not configured  `unsafe-inline` in their CSP.

fixes [#145](https://github.com/getsentry/rrweb/issues/145)
relates to [#10481](https://github.com/getsentry/sentry-javascript/issues/10481)

