### PR TITLE
feat: Fix blocking dynamically added iframes

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -331,7 +331,16 @@ export default class MutationBuffer {
         recordCanvas: this.recordCanvas,
         inlineImages: this.inlineImages,
         onSerialize: (currentN) => {
-          if (isSerializedIframe(currentN, this.mirror)) {
+          if (
+            isSerializedIframe(currentN, this.mirror) &&
+            !isBlocked(
+              currentN,
+              this.blockClass,
+              this.blockSelector,
+              this.unblockSelector,
+              false,
+            )
+          ) {
             this.iframeManager.addIframe(currentN as HTMLIFrameElement);
           }
           if (isSerializedStylesheet(currentN, this.mirror)) {
@@ -344,6 +353,18 @@ export default class MutationBuffer {
           }
         },
         onIframeLoad: (iframe, childSn) => {
+          if (
+            isBlocked(
+              iframe,
+              this.blockClass,
+              this.blockSelector,
+              this.unblockSelector,
+              false,
+            )
+          ) {
+            return;
+          }
+
           this.iframeManager.attachIframe(iframe, childSn);
           if (iframe.contentWindow) {
             this.canvasManager.addWindow(iframe.contentWindow as IWindow);

--- a/packages/rrweb/test/__snapshots__/integration.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/integration.test.ts.snap
@@ -13034,6 +13034,21 @@ exports[`record integration tests should not record blocked elements dynamically
           \\"nextId\\": 18,
           \\"node\\": {
             \\"type\\": 2,
+            \\"tagName\\": \\"iframe\\",
+            \\"attributes\\": {
+              \\"class\\": \\"rr-block\\",
+              \\"rr_width\\": \\"104px\\",
+              \\"rr_height\\": \\"104px\\"
+            },
+            \\"childNodes\\": [],
+            \\"id\\": 23
+          }
+        },
+        {
+          \\"parentId\\": 16,
+          \\"nextId\\": 23,
+          \\"node\\": {
+            \\"type\\": 2,
             \\"tagName\\": \\"button\\",
             \\"attributes\\": {
               \\"class\\": \\"rr-block\\",
@@ -13041,7 +13056,7 @@ exports[`record integration tests should not record blocked elements dynamically
               \\"rr_height\\": \\"100px\\"
             },
             \\"childNodes\\": [],
-            \\"id\\": 23
+            \\"id\\": 24
           }
         }
       ]

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -639,8 +639,15 @@ describe('record integration tests', function (this: ISuite) {
       el.style.height = '100px';
       el.innerText = 'Should not be recorded';
 
+      const iframe = document.createElement('iframe');
+      iframe.className = 'rr-block';
+      iframe.style.width = '100px';
+      iframe.style.height = '100px';
+      iframe.src = '#foo';
+
       const nextElement = document.querySelector('.rr-block')!;
       nextElement.parentNode!.insertBefore(el, nextElement);
+      nextElement.parentNode!.insertBefore(iframe, nextElement);
     });
 
     const snapshots = (await page.evaluate(


### PR DESCRIPTION
This fixes a bug with blocking iframes that are dynamically added to the DOM after the snapshot is taken. This ensures we check if iframe is considered blocked before adding to iframe manager.

Closes https://github.com/getsentry/sentry-javascript/issues/13173
