### PR TITLE
Replace Array.from with clean implementation (#1464)

### DIFF
--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -82,8 +82,7 @@ try {
   console.debug('Unable to override Array.from', err);
 }
 
-export const mirror = createMirror();
-
+const mirror = createMirror();
 function record<T = eventWithTime>(
   options: recordOptions<T> = {},
 ): listenerHandler | undefined {


### PR DESCRIPTION
This work is to try to provide support where rrweb might be included
in applications with various tools that might override Array.from
so that the 2nd parameter (the map function) will always work for
rrweb.

Co-authored-by: Michael Dellanoce <mdellanoce@pendo.io>