### PR TITLE
fix(rrweb): Do not re-initialize worker in CanvasManager.reset

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -123,13 +123,6 @@ export class CanvasManager implements CanvasManagerInterface {
     this.worker?.terminate();
     this.worker = null;
     this.snapshotInProgressMap = new Map();
-    if (
-      (this.options.recordCanvas &&
-        typeof this.options.sampling === 'number') ||
-      this.options.enableManualSnapshot
-    ) {
-      this.worker = this.initFPSWorker();
-    }
   }
 
   public freeze() {


### PR DESCRIPTION
`reset()` gets called when we stop a recording in progress. There is no reason to re-initialize the worker in `reset()` as you would need to call `record()` to start recording again, which would start a new worker. This was introduced in https://github.com/getsentry/rrweb/pull/168.
