### PR TITLE
fix(snapshot): Fix CSS expansion of `add` CSS property

### DIFF
--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -138,13 +138,18 @@ export function stringifyRule(rule: CSSRule): string {
     const needsAllFix =
       typeof rule.style['all'] === 'string' && rule.style['all'];
 
+    if (needsAllFix) {
+      cssText = fixAllCssProperty(rule);
+    }
+
     if (needsSafariColonFix) {
       // Safari does not escape selectors with : properly
       // see https://bugs.webkit.org/show_bug.cgi?id=184604
+      //
+      // This needs to be after `fixAllCssProperty()` which requires a
+      // `CssStylRule` and generates a string (i.e. `cssText`) and the below
+      // operates on `cssText`
       cssText = fixSafariColons(cssText);
-    }
-    if (needsAllFix) {
-      cssText = fixAllCssProperty(rule);
     }
 
     if (needsSafariColonFix || needsAllFix) {

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -113,7 +113,12 @@ export function stringifyStylesheet(s: CSSStyleSheet): string | null {
 export function fixAllCssProperty(rule: CSSStyleRule) {
   let styles = '';
   for (let i = 0; i < rule.style.length; i++) {
-    styles += `${rule.style[i]}:${rule.style.getPropertyValue(rule.style[i])};`;
+    const styleDeclaration = rule.style;
+    const attribute = styleDeclaration[i];
+    const isImportant = styleDeclaration.getPropertyPriority(attribute);
+    styles += `${attribute}:${styleDeclaration.getPropertyValue(attribute)}${
+      isImportant ? ` !important` : ''
+    };`;
   }
 
   return `${rule.selectorText} { ${styles} }`;

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -106,6 +106,19 @@ export function stringifyStylesheet(s: CSSStyleSheet): string | null {
   }
 }
 
+/**
+ * There is a bug in chrome (https://issues.chromium.org/issues/41416124) with the `all` property where we can't use `cssText` because it is wrong.
+ * Instead, attempt to serialize the css string using `CSSStyleDeclaration`.
+ */
+export function fixAllCssProperty(rule: CSSStyleRule) {
+  let styles = '';
+  for (let i = 0; i < rule.style.length; i++) {
+    styles += `${rule.style[i]}:${rule.style.getPropertyValue(rule.style[i])};`;
+  }
+
+  return `${rule.selectorText} { ${styles} }`;
+}
+
 export function stringifyRule(rule: CSSRule): string {
   let importStringified;
   if (isCSSImportRule(rule)) {
@@ -119,10 +132,24 @@ export function stringifyRule(rule: CSSRule): string {
     } catch (error) {
       // ignore
     }
-  } else if (isCSSStyleRule(rule) && rule.selectorText.includes(':')) {
-    // Safari does not escape selectors with : properly
-    // see https://bugs.webkit.org/show_bug.cgi?id=184604
-    return fixSafariColons(rule.cssText);
+  } else if (isCSSStyleRule(rule)) {
+    let cssText = rule.cssText;
+    const needsSafariColonFix = rule.selectorText.includes(':');
+    const needsAllFix =
+      typeof rule.style['all'] === 'string' && rule.style['all'];
+
+    if (needsSafariColonFix) {
+      // Safari does not escape selectors with : properly
+      // see https://bugs.webkit.org/show_bug.cgi?id=184604
+      cssText = fixSafariColons(cssText);
+    }
+    if (needsAllFix) {
+      cssText = fixAllCssProperty(rule);
+    }
+
+    if (needsSafariColonFix || needsAllFix) {
+      return cssText;
+    }
   }
 
   return importStringified || rule.cssText;

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -3555,6 +3555,109 @@ exports[`record no need for attribute mutations on adds 1`] = `
 ]"
 `;
 
+exports[`record records correct "all" CSS property order for snapshots and mutations 1`] = `
+"[
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"style\\",
+                    \\"attributes\\": {
+                      \\"_cssText\\": \\".btn { all:unset;padding-top:10px;padding-right:15px;padding-bottom:10px;padding-left:15px; }\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 5
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n          \\",
+                    \\"id\\": 7
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"input\\",
+                    \\"attributes\\": {
+                      \\"type\\": \\"text\\",
+                      \\"size\\": \\"40\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\\\n      \\\\n    \\",
+                    \\"id\\": 9
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"style\\": \\"all: unset; padding: 8px 4px;\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"Button\\",
+                        \\"id\\": 11
+                      }
+                    ],
+                    \\"id\\": 10
+                  }
+                ],
+                \\"id\\": 6
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  }
+]"
+`;
+
 exports[`record should record scroll position 1`] = `
 "[
   {

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -2428,6 +2428,109 @@ exports[`record captures stylesheets with \`blob:\` url 1`] = `
 ]"
 `;
 
+exports[`record handles \`!important\` with "all" CSS property 1`] = `
+"[
+  {
+    \\"type\\": 4,
+    \\"data\\": {
+      \\"href\\": \\"about:blank\\",
+      \\"width\\": 1920,
+      \\"height\\": 1080
+    }
+  },
+  {
+    \\"type\\": 2,
+    \\"data\\": {
+      \\"node\\": {
+        \\"type\\": 0,
+        \\"childNodes\\": [
+          {
+            \\"type\\": 1,
+            \\"name\\": \\"html\\",
+            \\"publicId\\": \\"\\",
+            \\"systemId\\": \\"\\",
+            \\"id\\": 2
+          },
+          {
+            \\"type\\": 2,
+            \\"tagName\\": \\"html\\",
+            \\"attributes\\": {},
+            \\"childNodes\\": [
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"head\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"style\\",
+                    \\"attributes\\": {
+                      \\"_cssText\\": \\".btn { all:unset !important;padding-top:10px !important;padding-right:15px !important;padding-bottom:10px !important;padding-left:15px !important; }\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 5
+                  }
+                ],
+                \\"id\\": 4
+              },
+              {
+                \\"type\\": 2,
+                \\"tagName\\": \\"body\\",
+                \\"attributes\\": {},
+                \\"childNodes\\": [
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n          \\",
+                    \\"id\\": 7
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"input\\",
+                    \\"attributes\\": {
+                      \\"type\\": \\"text\\",
+                      \\"size\\": \\"40\\"
+                    },
+                    \\"childNodes\\": [],
+                    \\"id\\": 8
+                  },
+                  {
+                    \\"type\\": 3,
+                    \\"textContent\\": \\"\\\\n        \\\\n      \\\\n    \\",
+                    \\"id\\": 9
+                  },
+                  {
+                    \\"type\\": 2,
+                    \\"tagName\\": \\"div\\",
+                    \\"attributes\\": {
+                      \\"style\\": \\"all: unset !important; padding: 8px 4px !important;\\"
+                    },
+                    \\"childNodes\\": [
+                      {
+                        \\"type\\": 3,
+                        \\"textContent\\": \\"Button\\",
+                        \\"id\\": 11
+                      }
+                    ],
+                    \\"id\\": 10
+                  }
+                ],
+                \\"id\\": 6
+              }
+            ],
+            \\"id\\": 3
+          }
+        ],
+        \\"id\\": 1
+      },
+      \\"initialOffset\\": {
+        \\"left\\": 0,
+        \\"top\\": 0
+      }
+    }
+  }
+]"
+`;
+
 exports[`record iframes captures stylesheet mutations in iframes 1`] = `
 "[
   {

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -736,7 +736,7 @@ describe('record', function (this: ISuite) {
     assertSnapshot(ctx.events);
   });
 
-  it.only('records correct "all" CSS property order for snapshots and mutations', async () => {
+  it('records correct "all" CSS property order for snapshots and mutations', async () => {
     await ctx.page.evaluate(() => {
       const { record } = (window as unknown as IWindow).rrweb;
 

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -736,6 +736,79 @@ describe('record', function (this: ISuite) {
     assertSnapshot(ctx.events);
   });
 
+  it.only('records correct "all" CSS property order for snapshots and mutations', async () => {
+    await ctx.page.evaluate(() => {
+      const { record } = (window as unknown as IWindow).rrweb;
+
+      const div = document.createElement('div');
+      div.setAttribute('style', 'all: unset; padding: 8px 4px;');
+      div.innerText = 'Button';
+      document.body.appendChild(div);
+
+      const styleElement = document.createElement('style');
+      document.head.appendChild(styleElement);
+
+      const styleSheet = <CSSStyleSheet>styleElement.sheet;
+      // begin: pre-serialization
+      styleSheet.insertRule('.btn { all: unset; padding: 10px 15px; }');
+
+      record({
+        emit: (window as unknown as IWindow).emit,
+      });
+    });
+    await ctx.page.waitForTimeout(50);
+    assertSnapshot(ctx.events);
+
+    await ctx.page.evaluate(() => {
+      const style = document.getElementsByTagName('style')[0];
+      (style.sheet as CSSStyleSheet).insertRule(
+        '.btn {all: unset; padding: 2px 4px;}',
+      );
+      const div = document.createElement('div');
+      div.setAttribute('style', 'all:unset;padding:3px 6px;');
+      document.body.appendChild(div);
+
+      const style2 = document.createElement('style');
+      document.head.appendChild(style2);
+
+      const styleSheet = <CSSStyleSheet>style2.sheet;
+      // begin: pre-serialization
+      styleSheet.insertRule('.btn2 { all: unset; padding: 4px 8px; }');
+    });
+    ctx.page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
+
+    await ctx.page.waitForTimeout(50);
+    const styleSheetMutations = ctx.events.filter(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        e.data.source === IncrementalSource.StyleSheetRule,
+    );
+    const mutations = ctx.events.filter(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        e.data.source === IncrementalSource.Mutation,
+    );
+
+    // @ts-expect-error data is unknown
+    expect(styleSheetMutations[0].data.adds).toEqual([
+      {
+        rule: '.btn {all: unset; padding: 2px 4px;}',
+      },
+    ]);
+    // @ts-expect-error data is unknown
+    expect(mutations[0].data.adds[0].node.attributes).toEqual({
+      style: 'all:unset;padding:3px 6px;',
+    });
+    // @ts-expect-error data is unknown
+    expect(mutations[0].data.adds[1].node).toMatchObject({
+      tagName: 'style',
+      attributes: {
+        _cssText:
+          '.btn2 { all:unset;padding-top:4px;padding-right:8px;padding-bottom:4px;padding-left:8px; }',
+      },
+    });
+  });
+
   describe('loading stylesheets', () => {
     let server: Server;
     let serverURL: string;

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -749,7 +749,6 @@ describe('record', function (this: ISuite) {
       document.head.appendChild(styleElement);
 
       const styleSheet = <CSSStyleSheet>styleElement.sheet;
-      // begin: pre-serialization
       styleSheet.insertRule('.btn { all: unset; padding: 10px 15px; }');
 
       record({
@@ -772,7 +771,6 @@ describe('record', function (this: ISuite) {
       document.head.appendChild(style2);
 
       const styleSheet = <CSSStyleSheet>style2.sheet;
-      // begin: pre-serialization
       styleSheet.insertRule('.btn2 { all: unset; padding: 4px 8px; }');
     });
     ctx.page.on('console', (msg) => console.log('PAGE LOG:', msg.text()));
@@ -807,6 +805,34 @@ describe('record', function (this: ISuite) {
           '.btn2 { all:unset;padding-top:4px;padding-right:8px;padding-bottom:4px;padding-left:8px; }',
       },
     });
+  });
+
+  it('handles `!important` with "all" CSS property', async () => {
+    await ctx.page.evaluate(() => {
+      const { record } = (window as unknown as IWindow).rrweb;
+
+      const div = document.createElement('div');
+      div.setAttribute(
+        'style',
+        'all: unset !important; padding: 8px 4px !important;',
+      );
+      div.innerText = 'Button';
+      document.body.appendChild(div);
+
+      const styleElement = document.createElement('style');
+      document.head.appendChild(styleElement);
+
+      const styleSheet = <CSSStyleSheet>styleElement.sheet;
+      styleSheet.insertRule(
+        '.btn { all: unset !important; padding: 10px 15px !important; }',
+      );
+
+      record({
+        emit: (window as unknown as IWindow).emit,
+      });
+    });
+    await ctx.page.waitForTimeout(50);
+    assertSnapshot(ctx.events);
   });
 
   describe('loading stylesheets', () => {


### PR DESCRIPTION
Adds a workaround for [this Chrome bug](https://issues.chromium.org/issues/41416124) where the CSS property `all` gets expanded by Chrome and can potentially override user defined CSS.

Ref https://github.com/getsentry/team-replay/issues/504

## Example

### CSS as defined by user

```
.btn {
  all: unset;
  padding: 10px 15px;
}
```

### After Chrome serialization

```css
.btn {
  color: unset;
  font: unset;
  font-palette: unset;
  font-synthesis: unset;
  forced-color-adjust: unset;
  text-orientation: unset;
  text-rendering: unset;
  -webkit-font-smoothing: unset;
  -webkit-locale: unset;
  -webkit-text-orientation: unset;
  -webkit-writing-mode: unset;
  writing-mode: unset;
  zoom: unset;
  accent-color: unset;
  place-content: unset;
  place-items: unset;
  place-self: unset;
  alignment-baseline: unset;
  animation-composition: unset;
  animation: unset;
  app-region: unset;
  appearance: unset;
  aspect-ratio: unset;
  backdrop-filter: unset;
  backface-visibility: unset;
  background: unset;
  background-blend-mode: unset;
  baseline-shift: unset;
  baseline-source: unset;
  block-size: unset;
  border-block: unset;
  border: unset;
  border-radius: unset;
  border-collapse: unset;
  border-end-end-radius: unset;
  border-end-start-radius: unset;
  border-inline: unset;
  border-start-end-radius: unset;
  border-start-start-radius: unset;
  inset: unset;
  box-shadow: unset;
  box-sizing: unset;
  break-after: unset;
  break-before: unset;
  break-inside: unset;
  buffered-rendering: unset;
  caption-side: unset;
  caret-color: unset;
  clear: unset;
  clip: unset;
  clip-path: unset;
  clip-rule: unset;
  color-interpolation: unset;
  color-interpolation-filters: unset;
  color-rendering: unset;
  color-scheme: unset;
  columns: unset;
  column-fill: unset;
  gap: unset;
  column-rule: unset;
  column-span: unset;
  contain: unset;
  contain-intrinsic-block-size: unset;
  contain-intrinsic-size: unset;
  contain-intrinsic-inline-size: unset;
  container: unset;
  content: unset;
  content-visibility: unset;
  counter-increment: unset;
  counter-reset: unset;
  counter-set: unset;
  cursor: unset;
  cx: unset;
  cy: unset;
  d: unset;
  display: unset;
  dominant-baseline: unset;
  empty-cells: unset;
  fill: unset;
  fill-opacity: unset;
  fill-rule: unset;
  filter: unset;
  flex: unset;
  flex-flow: unset;
  float: unset;
  flood-color: unset;
  flood-opacity: unset;
  grid: unset;
  grid-area: unset;
  height: unset;
  hyphenate-character: unset;
  hyphenate-limit-chars: unset;
  hyphens: unset;
  image-orientation: unset;
  image-rendering: unset;
  initial-letter: unset;
  inline-size: unset;
  inset-block: unset;
  inset-inline: unset;
  isolation: unset;
  letter-spacing: unset;
  lighting-color: unset;
  line-break: unset;
  list-style: unset;
  margin-block: unset;
  margin: unset;
  margin-inline: unset;
  marker: unset;
  mask: unset;
  mask-type: unset;
  math-depth: unset;
  math-shift: unset;
  math-style: unset;
  max-block-size: unset;
  max-height: unset;
  max-inline-size: unset;
  max-width: unset;
  min-block-size: unset;
  min-height: unset;
  min-inline-size: unset;
  min-width: unset;
  mix-blend-mode: unset;
  object-fit: unset;
  object-position: unset;
  object-view-box: unset;
  offset: unset;
  opacity: unset;
  order: unset;
  orphans: unset;
  outline: unset;
  outline-offset: unset;
  overflow-anchor: unset;
  overflow-clip-margin: unset;
  overflow-wrap: unset;
  overflow: unset;
  overscroll-behavior-block: unset;
  overscroll-behavior-inline: unset;
  overscroll-behavior: unset;
  padding-block: unset;
  padding: 10px 15px;
  padding-inline: unset;
  page: unset;
  page-orientation: unset;
  paint-order: unset;
  perspective: unset;
  perspective-origin: unset;
  pointer-events: unset;
  position: unset;
  quotes: unset;
  r: unset;
  resize: unset;
  rotate: unset;
  ruby-position: unset;
  rx: unset;
  ry: unset;
  scale: unset;
  scroll-behavior: unset;
  scroll-margin-block: unset;
  scroll-margin: unset;
  scroll-margin-inline: unset;
  scroll-padding-block: unset;
  scroll-padding: unset;
  scroll-padding-inline: unset;
  scroll-snap-align: unset;
  scroll-snap-stop: unset;
  scroll-snap-type: unset;
  scroll-timeline: unset;
  scrollbar-gutter: unset;
  shape-image-threshold: unset;
  shape-margin: unset;
  shape-outside: unset;
  shape-rendering: unset;
  size: unset;
  speak: unset;
  stop-color: unset;
  stop-opacity: unset;
  stroke: unset;
  stroke-dasharray: unset;
  stroke-dashoffset: unset;
  stroke-linecap: unset;
  stroke-linejoin: unset;
  stroke-miterlimit: unset;
  stroke-opacity: unset;
  stroke-width: unset;
  tab-size: unset;
  table-layout: unset;
  text-align: unset;
  text-align-last: unset;
  text-anchor: unset;
  text-combine-upright: unset;
  text-decoration: unset;
  text-decoration-skip-ink: unset;
  text-emphasis: unset;
  text-emphasis-position: unset;
  text-indent: unset;
  text-overflow: unset;
  text-shadow: unset;
  text-size-adjust: unset;
  text-transform: unset;
  text-underline-offset: unset;
  text-underline-position: unset;
  white-space: unset;
  touch-action: unset;
  transform: unset;
  transform-box: unset;
  transform-origin: unset;
  transform-style: unset;
  transition: unset;
  translate: unset;
  user-select: unset;
  vector-effect: unset;
  vertical-align: unset;
  view-timeline: unset;
  view-timeline-inset: unset;
  view-transition-name: unset;
  visibility: unset;
  border-spacing: unset;
  -webkit-box-align: unset;
  -webkit-box-decoration-break: unset;
  -webkit-box-direction: unset;
  -webkit-box-flex: unset;
  -webkit-box-ordinal-group: unset;
  -webkit-box-orient: unset;
  -webkit-box-pack: unset;
  -webkit-box-reflect: unset;
  -webkit-highlight: unset;
  -webkit-line-break: unset;
  -webkit-line-clamp: unset;
  -webkit-mask-box-image: unset;
  -webkit-mask: unset;
  -webkit-mask-composite: unset;
  -webkit-print-color-adjust: unset;
  -webkit-rtl-ordering: unset;
  -webkit-ruby-position: unset;
  -webkit-tap-highlight-color: unset;
  -webkit-text-combine: unset;
  -webkit-text-decorations-in-effect: unset;
  -webkit-text-fill-color: unset;
  -webkit-text-security: unset;
  -webkit-text-stroke: unset;
  -webkit-user-drag: unset;
  -webkit-user-modify: unset;
  widows: unset;
  width: unset;
  will-change: unset;
  word-break: unset;
  word-spacing: unset;
  x: unset;
  y: unset;
  z-index: unset;
}
```

### After fix

```css
.btn {
  all:unset;
  padding-top:10px;
  padding-right:15px;
  padding-bottom:10px;
  padding-left:15px;
}
```
