### PR TITLE
fix(snapshot): Change to ignore all `link[rel="modulepreload"]`

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -8,7 +8,12 @@ import {
   attributes,
   legacyAttributes,
 } from './types';
-import { isElement, Mirror, isNodeMetaEqual } from './utils';
+import {
+  isElement,
+  Mirror,
+  isNodeMetaEqual,
+  extractFileExtension,
+} from './utils';
 
 const tagMap: tagMap = {
   script: 'noscript',
@@ -245,15 +250,14 @@ function buildNode(
           } else if (
             tagName === 'link' &&
             (n.attributes.rel === 'preload' ||
-              n.attributes.rel === 'modulepreload') &&
-            n.attributes.as === 'script'
+              n.attributes.rel === 'modulepreload')
           ) {
             // ignore
           } else if (
             tagName === 'link' &&
             n.attributes.rel === 'prefetch' &&
             typeof n.attributes.href === 'string' &&
-            n.attributes.href.endsWith('.js')
+            extractFileExtension(n.attributes.href) === 'js'
           ) {
             // ignore
           } else if (

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1099,8 +1099,7 @@ function slimDOMExcluded(
         // (module)preload link
         (sn.tagName === 'link' &&
           (sn.attributes.rel === 'preload' ||
-            sn.attributes.rel === 'modulepreload') &&
-          sn.attributes.as === 'script') ||
+            sn.attributes.rel === 'modulepreload')) ||
         // prefetch link
         (sn.tagName === 'link' &&
           sn.attributes.rel === 'prefetch' &&


### PR DESCRIPTION
... removes requirement to have `as="script"` attribute. Also fixes prefetch to extract file extension instead of checking end of string since there can be URL parameters.
