### PR TITLE
test(rrweb): Re-enable skipped test

### DIFF
--- a/packages/rrweb/test/record/cross-origin-iframes.test.ts
+++ b/packages/rrweb/test/record/cross-origin-iframes.test.ts
@@ -205,8 +205,7 @@ describe('cross origin iframes', function (this: ISuite) {
       ).not.toBe(1);
     });
 
-    // This test is quite flakey in CI
-    it.skip('should replace the existing DOM nodes on iframe navigation with `isAttachIframe`', async () => {
+    it('should replace the existing DOM nodes on iframe navigation with `isAttachIframe`', async () => {
       await ctx.page.evaluate((url) => {
         const iframe = document.querySelector('iframe') as HTMLIFrameElement;
         iframe.src = `${url}/html/form.html?2`;


### PR DESCRIPTION
Re-enables test that was skipped in https://github.com/getsentry/rrweb/pull/172;
