### PR TITLE
perf(replayer): Prevent infinte loops with resolve trees

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1760,6 +1760,7 @@ export class Replayer {
     });
 
     const startTime = Date.now();
+    const resolvedTreeNodes = new WeakSet();
     while (queue.length) {
       // transform queue to resolve tree
       const resolveTrees = queueToResolveTrees(queue);
@@ -1780,7 +1781,10 @@ export class Replayer {
           );
         } else {
           iterateResolveTree(tree, (mutation) => {
-            appendNode(mutation);
+            if (!resolvedTreeNodes.has(mutation)) {
+              resolvedTreeNodes.add(mutation);
+              appendNode(mutation);
+            }
           });
         }
       }


### PR DESCRIPTION
This prevents an infinite loop from ocurring by keeping a Weakset of previously resolved nodes. Previously (it still does too), this loop would timeout after 500ms.
