### PR TITLE
ref(rrweb): WIP: refactor sideeffects from rrweb/record

### DIFF
--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -58,7 +58,9 @@
     "dist",
     "package.json"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/record/clean-array-from.ts"
+  ],
   "author": "yanzhen@smartx.com",
   "license": "MIT",
   "bugs": {

--- a/packages/rrweb/src/record/clean-array-from.ts
+++ b/packages/rrweb/src/record/clean-array-from.ts
@@ -1,0 +1,15 @@
+// Multiple tools (i.e. MooTools, Prototype.js) override Array.from and drop support for the 2nd parameter
+// Try to pull a clean implementation from a newly created iframe
+try {
+  if (Array.from([1], (x) => x * 2)[0] !== 2) {
+    const cleanFrame = document.createElement('iframe');
+    document.body.appendChild(cleanFrame);
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- Array.from is static and doesn't rely on binding
+    Array.from = cleanFrame.contentWindow?.Array.from || Array.from;
+    document.body.removeChild(cleanFrame);
+  }
+} catch (err) {
+  console.debug('Unable to override Array.from', err);
+}
+
+export {};


### PR DESCRIPTION
This seems to be causing slight issues for our replayCanvasIntegration. `createMirror()` gets included twice (once for replayCanvasIntegration and once for replayIntegration).