### PR TITLE
ci: fix `download-artifact` deprecation, upgrade eslint-annotate-action

### DIFF
--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ESLint Annotation
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: eslint_report.json
       - name: Annotate Code Linting Results

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           name: eslint_report.json
       - name: Annotate Code Linting Results
-        uses: ataylorme/eslint-annotate-action@v3
+        uses: ataylorme/eslint-annotate-action@d57a1193d4c59cbfbf3f86c271f42612f9dbd9e9
         with:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'eslint_report.json'

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -44,9 +44,9 @@ jobs:
         with:
           name: eslint_report.json
       - name: Annotate Code Linting Results
-        uses: ataylorme/eslint-annotate-action@v2
+        uses: ataylorme/eslint-annotate-action@v3
         with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'eslint_report.json'
 
   prettier_check:


### PR DESCRIPTION
I think this needs to be in main branch for it to work