### PR TITLE
fix(snapshot): Do not attempt to load iframe at all if it is blocked

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1375,7 +1375,13 @@ export function serializeNodeWithId(
 
   if (
     serializedNode.type === NodeType.Element &&
-    serializedNode.tagName === 'iframe'
+    serializedNode.tagName === 'iframe' &&
+    !_isBlockedElement(
+      n as HTMLIFrameElement,
+      blockClass,
+      blockSelector,
+      unblockSelector,
+    )
   ) {
     onceIframeLoaded(
       n as HTMLIFrameElement,


### PR DESCRIPTION
Do not attach a `load` event listener to an iframe that is blocked. This should solve the problem where Safari will complain about accessing a frame from a different origin.

Closes https://github.com/getsentry/sentry-javascript/issues/13173