### PR TITLE
fix(snapshot): Do not create CDATA node on HTMLDocument

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -360,6 +360,12 @@ function buildNode(
           : n.textContent,
       );
     case NodeType.CDATA:
+      // `createCDATASection` only works for XML documents (not HTML)
+      // https://developer.mozilla.org/en-US/docs/Web/API/Document/createCDATASection#notes
+      if (!(doc instanceof XMLDocument)) {
+        return null;
+      }
+
       return doc.createCDATASection(n.textContent);
     case NodeType.Comment:
       return doc.createComment(n.textContent);


### PR DESCRIPTION
`createCDATASection` is [only supported on XMLDocument](https://developer.mozilla.org/en-US/docs/Web/API/Document/createCDATASection#notes), not HTMLDocument. Doing so on HTMLDocument will throw an exception and break playback on the player.

This change will log a "Failed to rebuild" warning to the console instead of throwing.

Fixes https://sentry.sentry.io/issues/5222059335/?project=11276&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=90d&stream_index=11
