### PR TITLE
fix(record): Catch exceptions when accessing `window.document`

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -431,6 +431,7 @@ export class CanvasManager implements CanvasManagerInterface {
         }
 
         if (_document) {
+          // This is not included in the `try` block above in case `searchCanvas()` throws
           searchCanvas(_document);
         }
       }

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -419,8 +419,19 @@ export class CanvasManager implements CanvasManagerInterface {
 
       for (const item of this.windows) {
         const window = item.deref();
-        if (window) {
-          searchCanvas(window.document);
+        let _document: Document | false | undefined;
+
+        try {
+          _document = window && window.document;
+        } catch {
+          // Accesing `window.document` can throw a security error:
+          // "Failed to read a named property 'document' from 'Window': An
+          // attempt was made to break through the security policy of the user
+          // agent."
+        }
+
+        if (_document) {
+          searchCanvas(_document);
         }
       }
 


### PR DESCRIPTION
In CanvasManager, catch exceptions when accessing `window.document` as it can throw a `SecurityError`:

"SecurityError: Failed to read a named property 'document' from 'Window': An attempt was made to break through the security policy of the user agent."


Fixes [JAVASCRIPT-2X1A](https://sentry.sentry.io/issues/6124877975/events/dcd238939c8147e2b97bb7fc510f1b5a/)
