### PR TITLE
fix(utils): Safely access `node.nodeType`

### DIFF
--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -229,11 +229,17 @@ export function closestElementOfNode(node: Node | null): HTMLElement | null {
   if (!node) {
     return null;
   }
-  const el: HTMLElement | null =
-    node.nodeType === node.ELEMENT_NODE
-      ? (node as HTMLElement)
-      : node.parentElement;
-  return el;
+
+  // Catch access to node properties to avoid Firefox "permission denied" errors
+  try {
+    const el: HTMLElement | null =
+      node.nodeType === node.ELEMENT_NODE
+        ? (node as HTMLElement)
+        : node.parentElement;
+    return el;
+  } catch (error) {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Access to `node.nodeType` can throw on FF when using the internal screenshot tool.

closes https://github.com/getsentry/sentry-javascript/issues/15559