### PR TITLE
fix: Check for `node.childNodes` before accessing them

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1346,7 +1346,8 @@ export function serializeNodeWithId(
       stylesheetLoadTimeout,
       keepIframeSrcFn,
     };
-    for (const childN of Array.from(n.childNodes)) {
+    const childNodes = n.childNodes ? Array.from(n.childNodes) : [];
+    for (const childN of childNodes) {
       const serializedChildNode = serializeNodeWithId(childN, bypassOptions);
       if (serializedChildNode) {
         serializedNode.childNodes.push(serializedChildNode);

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -850,9 +850,7 @@ export default class MutationBuffer {
  */
 function deepDelete(addsSet: Set<Node>, n: Node) {
   addsSet.delete(n);
-  if (n.childNodes) {
-    n.childNodes.forEach((childN) => deepDelete(addsSet, childN));
-  }
+  n.childNodes?.forEach((childN) => deepDelete(addsSet, childN));
 }
 
 function isParentRemoved(

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -829,7 +829,9 @@ export default class MutationBuffer {
         false,
       )
     ) {
-      n.childNodes.forEach((childN) => this.genAdds(childN));
+      if (n.childNodes) {
+        n.childNodes.forEach((childN) => this.genAdds(childN));
+      }
       if (hasShadowRoot(n)) {
         n.shadowRoot.childNodes.forEach((childN) => {
           this.processedNodeManager.add(childN, this);
@@ -848,7 +850,9 @@ export default class MutationBuffer {
  */
 function deepDelete(addsSet: Set<Node>, n: Node) {
   addsSet.delete(n);
-  n.childNodes.forEach((childN) => deepDelete(addsSet, childN));
+  if (n.childNodes) {
+    n.childNodes.forEach((childN) => deepDelete(addsSet, childN));
+  }
 }
 
 function isParentRemoved(


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/API/Node/childNodes#simple_usage

This is typed weirdly, because apparently you should check for existence here. Technically doing `node.hasChildNodes()` would be correct, but since we tend to serialize stuff here or there I feel this is safer (and we already do that in other places too).

Closes https://github.com/getsentry/sentry-javascript/issues/15948