### PR TITLE
feat(snapshot): Update blocked image dimensions after load

### DIFF
--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1555,6 +1555,7 @@ function snapshot(
     onBlockedImageLoad?: (
       imageEl: HTMLImageElement,
       node: serializedElementNodeWithId,
+      rect: DOMRect,
     ) => unknown;
     onStylesheetLoad?: (
       linkNode: HTMLLinkElement,

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1449,7 +1449,6 @@ export function serializeNodeWithId(
           }
         } catch (error) {
           // Silently handle errors from getBoundingClientRect
-          console.warn('Failed to get image dimensions:', error);
         }
       }
       image.removeEventListener('load', updateImageDimensions);

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1431,14 +1431,22 @@ export function serializeNodeWithId(
     );
   }
 
-  if (serializedNode.type === NodeType.Element && serializedNode.tagName === 'img' && !(n as HTMLImageElement).complete && 
-  serializedNode.needBlock) {
-      const updateImageDimensions = () => {
-        const image = n as HTMLImageElement;
-        onBlockedImageLoad?.(image, serializedNode, image.getBoundingClientRect());
-        image.removeEventListener('load', updateImageDimensions);
-      };
-      n.addEventListener('load', updateImageDimensions);
+  if (
+    serializedNode.type === NodeType.Element &&
+    serializedNode.tagName === 'img' &&
+    !(n as HTMLImageElement).complete &&
+    serializedNode.needBlock
+  ) {
+    const updateImageDimensions = () => {
+      const image = n as HTMLImageElement;
+      onBlockedImageLoad?.(
+        image,
+        serializedNode,
+        image.getBoundingClientRect(),
+      );
+      image.removeEventListener('load', updateImageDimensions);
+    };
+    n.addEventListener('load', updateImageDimensions);
   }
 
   // <link rel=stylesheet href=...>

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1203,6 +1203,11 @@ export function serializeNodeWithId(
       node: serializedElementNodeWithId,
     ) => unknown;
     iframeLoadTimeout?: number;
+    onBlockedImageLoad?: (
+      imageEl: HTMLImageElement,
+      node: serializedElementNodeWithId,
+      rect: DOMRect,
+    ) => unknown;
     onStylesheetLoad?: (
       linkNode: HTMLLinkElement,
       node: serializedElementNodeWithId,
@@ -1234,6 +1239,7 @@ export function serializeNodeWithId(
     onSerialize,
     onIframeLoad,
     iframeLoadTimeout = 5000,
+    onBlockedImageLoad,
     onStylesheetLoad,
     stylesheetLoadTimeout = 5000,
     keepIframeSrcFn = () => false,
@@ -1298,8 +1304,6 @@ export function serializeNodeWithId(
   let recordChild = !skipChild;
   if (serializedNode.type === NodeType.Element) {
     recordChild = recordChild && !serializedNode.needBlock;
-    // this property was not needed in replay side
-    delete serializedNode.needBlock;
     const shadowRoot = (n as HTMLElement).shadowRoot;
     if (shadowRoot && isNativeShadowDom(shadowRoot))
       serializedNode.isShadowHost = true;
@@ -1342,6 +1346,7 @@ export function serializeNodeWithId(
       onSerialize,
       onIframeLoad,
       iframeLoadTimeout,
+      onBlockedImageLoad,
       onStylesheetLoad,
       stylesheetLoadTimeout,
       keepIframeSrcFn,
@@ -1377,12 +1382,7 @@ export function serializeNodeWithId(
   if (
     serializedNode.type === NodeType.Element &&
     serializedNode.tagName === 'iframe' &&
-    !_isBlockedElement(
-      n as HTMLIFrameElement,
-      blockClass,
-      blockSelector,
-      unblockSelector,
-    )
+    !serializedNode.needBlock
   ) {
     onceIframeLoaded(
       n as HTMLIFrameElement,
@@ -1429,6 +1429,16 @@ export function serializeNodeWithId(
       },
       iframeLoadTimeout,
     );
+  }
+
+  if (serializedNode.type === NodeType.Element && serializedNode.tagName === 'img' && !(n as HTMLImageElement).complete && 
+  serializedNode.needBlock) {
+      const updateImageDimensions = () => {
+        const image = n as HTMLImageElement;
+        onBlockedImageLoad?.(image, serializedNode, image.getBoundingClientRect());
+        image.removeEventListener('load', updateImageDimensions);
+      };
+      n.addEventListener('load', updateImageDimensions);
   }
 
   // <link rel=stylesheet href=...>
@@ -1487,6 +1497,11 @@ export function serializeNodeWithId(
     );
   }
 
+  if (serializedNode.type === NodeType.Element) {
+    // this property was not needed in replay side
+    delete serializedNode.needBlock;
+  }
+
   return serializedNode;
 }
 
@@ -1518,6 +1533,10 @@ function snapshot(
       node: serializedElementNodeWithId,
     ) => unknown;
     iframeLoadTimeout?: number;
+    onBlockedImageLoad?: (
+      imageEl: HTMLImageElement,
+      node: serializedElementNodeWithId,
+    ) => unknown;
     onStylesheetLoad?: (
       linkNode: HTMLLinkElement,
       node: serializedElementNodeWithId,
@@ -1549,6 +1568,7 @@ function snapshot(
     onSerialize,
     onIframeLoad,
     iframeLoadTimeout,
+    onBlockedImageLoad,
     onStylesheetLoad,
     stylesheetLoadTimeout,
     keepIframeSrcFn = () => false,
@@ -1618,6 +1638,7 @@ function snapshot(
     onSerialize,
     onIframeLoad,
     iframeLoadTimeout,
+    onBlockedImageLoad,
     onStylesheetLoad,
     stylesheetLoadTimeout,
     keepIframeSrcFn,

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1437,16 +1437,28 @@ export function serializeNodeWithId(
     !(n as HTMLImageElement).complete &&
     serializedNode.needBlock
   ) {
+    const image = n as HTMLImageElement;
     const updateImageDimensions = () => {
-      const image = n as HTMLImageElement;
-      onBlockedImageLoad?.(
-        image,
-        serializedNode,
-        image.getBoundingClientRect(),
-      );
+      // Check if the element is still in the DOM and not already complete
+      if (image.isConnected && !image.complete && onBlockedImageLoad) {
+        try {
+          const rect = image.getBoundingClientRect();
+          // Only proceed if we have valid dimensions
+          if (rect.width > 0 && rect.height > 0) {
+            onBlockedImageLoad(image, serializedNode, rect);
+          }
+        } catch (error) {
+          // Silently handle errors from getBoundingClientRect
+          console.warn('Failed to get image dimensions:', error);
+        }
+      }
       image.removeEventListener('load', updateImageDimensions);
     };
-    n.addEventListener('load', updateImageDimensions);
+
+    // Only add listener if element is still in DOM
+    if (image.isConnected) {
+      image.addEventListener('load', updateImageDimensions);
+    }
   }
 
   // <link rel=stylesheet href=...>

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -624,7 +624,6 @@ describe('image loading', () => {
       </html>
     `);
 
-    // const doc = dom.window.document;
     const mirror = new Mirror();
     const onBlockedImageLoad = vi.fn();
 

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -11,7 +11,7 @@ import {
   needMaskingText,
 } from '../src/snapshot';
 import snapshot from '../src/snapshot';
-import { serializedNodeWithId } from '../src/types';
+import { serializedNodeWithId, NodeType } from '../src/types';
 import { Mirror } from '../src/utils';
 
 describe('absolute url to stylesheet', () => {
@@ -602,5 +602,258 @@ describe('jsdom snapshot', () => {
     expect(sn).toMatchObject({
       type: 0,
     });
+  });
+});
+
+describe('image loading', () => {
+  const render = (html: string): Document => {
+    document.write(html);
+    return document;
+  };
+
+  it('should trigger onBlockedImageLoad callback when blocked image loads', async () => {
+    const doc = render(`
+      <!DOCTYPE html>
+      <html>
+        <head></head>
+        <body>
+          <div>
+            <img src="data:image/gif;base64," class="rr-block" />
+          </div>
+        </body>
+      </html>
+    `);
+
+    // const doc = dom.window.document;
+    const mirror = new Mirror();
+    const onBlockedImageLoad = vi.fn();
+
+    // Mock the image to simulate incomplete loading
+    const img = doc.querySelector('img') as HTMLImageElement;
+    Object.defineProperty(img, 'complete', {
+      value: false,
+      writable: true,
+    });
+
+    // Serialize the node with the onBlockedImageLoad callback
+    const serializedNode = serializeNodeWithId(img, {
+      doc,
+      mirror,
+      blockClass: 'rr-block',
+      blockSelector: null,
+      unblockSelector: null,
+      maskAllText: false,
+      maskTextClass: 'rr-mask',
+      unmaskTextClass: null,
+      maskTextSelector: null,
+      unmaskTextSelector: null,
+      skipChild: false,
+      inlineStylesheet: true,
+      maskInputOptions: {},
+      maskAttributeFn: undefined,
+      maskTextFn: undefined,
+      maskInputFn: undefined,
+      slimDOMOptions: {},
+      dataURLOptions: {},
+      inlineImages: false,
+      recordCanvas: false,
+      preserveWhiteSpace: true,
+      onSerialize: undefined,
+      onIframeLoad: undefined,
+      iframeLoadTimeout: 5000,
+      onBlockedImageLoad,
+      onStylesheetLoad: undefined,
+      stylesheetLoadTimeout: 5000,
+      keepIframeSrcFn: () => false,
+      newlyAddedElement: false,
+    });
+
+    expect(serializedNode?.type).toEqual(NodeType.Element);
+    if (serializedNode?.type === NodeType.Element) { // for typescript
+      expect(serializedNode?.attributes.rr_width).toBe('0px');
+      expect(serializedNode?.attributes.rr_height).toBe('0px');
+    }
+
+    // Mock getBoundingClientRect to return specific dimensions
+    const mockRect = {
+      width: 100,
+      height: 150,
+      top: 0,
+      left: 0,
+      bottom: 150,
+      right: 100,
+    };
+    img.getBoundingClientRect = vi.fn().mockReturnValue(mockRect);
+
+    // Simulate the image load event
+    const loadEvent = new window.Event('load');
+    img.dispatchEvent(loadEvent);
+
+    // Verify that onBlockedImageLoad was called with correct parameters
+    expect(onBlockedImageLoad).toHaveBeenCalledTimes(1);
+    expect(onBlockedImageLoad).toHaveBeenCalledWith(
+      img,
+      serializedNode,
+      mockRect
+    );
+  });
+
+  it('should not trigger onBlockedImageLoad for non-blocked images', async () => {
+    const doc = render(`
+      <!DOCTYPE html>
+      <html>
+        <head></head>
+        <body>
+          <div>
+            <img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" />
+          </div>
+        </body>
+      </html>
+    `);
+
+    const mirror = new Mirror();
+    const onBlockedImageLoad = vi.fn();
+
+    // Mock the image to simulate incomplete loading
+    const img = doc.querySelector('img') as HTMLImageElement;
+    Object.defineProperty(img, 'complete', {
+      value: false,
+      writable: true,
+    });
+
+    // Serialize the node with the onBlockedImageLoad callback
+    const serializedNode = serializeNodeWithId(img, {
+      doc,
+      mirror,
+      blockClass: 'rr-block',
+      blockSelector: null,
+      unblockSelector: null,
+      maskAllText: false,
+      maskTextClass: 'rr-mask',
+      unmaskTextClass: null,
+      maskTextSelector: null,
+      unmaskTextSelector: null,
+      skipChild: false,
+      inlineStylesheet: true,
+      maskInputOptions: {},
+      maskAttributeFn: undefined,
+      maskTextFn: undefined,
+      maskInputFn: undefined,
+      slimDOMOptions: {},
+      dataURLOptions: {},
+      inlineImages: false,
+      recordCanvas: false,
+      preserveWhiteSpace: true,
+      onSerialize: undefined,
+      onIframeLoad: undefined,
+      iframeLoadTimeout: 5000,
+      onBlockedImageLoad,
+      onStylesheetLoad: undefined,
+      stylesheetLoadTimeout: 5000,
+      keepIframeSrcFn: () => false,
+      newlyAddedElement: false,
+    });
+
+    expect(serializedNode).toEqual(expect.objectContaining({
+      type: 2,
+      tagName: 'img',
+      attributes: {
+        src: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+      },
+      id: 1,
+    }))
+
+    // Simulate the image load event
+    const loadEvent = new window.Event('load');
+    img.dispatchEvent(loadEvent);
+
+    // Verify that onBlockedImageLoad was called with correct parameters
+    expect(onBlockedImageLoad).not.toHaveBeenCalled();
+  });
+
+  it.only('should not trigger onBlockedImageLoad for already complete images', async () => {
+    const doc = render(`
+      <!DOCTYPE html>
+      <html>
+        <head></head>
+        <body>
+          <div>
+            <img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" class="rr-block" />
+          </div>
+        </body>
+      </html>
+    `);
+
+    const mirror = new Mirror();
+    const onBlockedImageLoad = vi.fn();
+
+    // Mock the image to simulate already complete loading
+    const img = doc.querySelector('img') as HTMLImageElement;
+    Object.defineProperty(img, 'complete', {
+      value: true,
+      writable: true,
+    });
+
+    // Mock getBoundingClientRect to return specific dimensions
+    const mockRect = {
+      width: 100,
+      height: 150,
+      top: 0,
+      left: 0,
+      bottom: 150,
+      right: 100,
+    };
+    img.getBoundingClientRect = vi.fn().mockReturnValue(mockRect);
+
+    // Serialize the node with the onBlockedImageLoad callback
+    const serializedNode = serializeNodeWithId(img, {
+      doc,
+      mirror,
+      blockClass: 'rr-block',
+      blockSelector: null,
+      unblockSelector: null,
+      maskAllText: false,
+      maskTextClass: 'rr-mask',
+      unmaskTextClass: null,
+      maskTextSelector: null,
+      unmaskTextSelector: null,
+      skipChild: false,
+      inlineStylesheet: true,
+      maskInputOptions: {},
+      maskAttributeFn: undefined,
+      maskTextFn: undefined,
+      maskInputFn: undefined,
+      slimDOMOptions: {},
+      dataURLOptions: {},
+      inlineImages: false,
+      recordCanvas: false,
+      preserveWhiteSpace: true,
+      onSerialize: undefined,
+      onIframeLoad: undefined,
+      iframeLoadTimeout: 5000,
+      onBlockedImageLoad,
+      onStylesheetLoad: undefined,
+      stylesheetLoadTimeout: 5000,
+      keepIframeSrcFn: () => false,
+      newlyAddedElement: false,
+    });
+
+    console.log(serializedNode);
+    expect(serializedNode).toEqual(expect.objectContaining({
+      type: 2,
+      tagName: 'img',
+      attributes: {
+        class: 'rr-block',
+        rr_width: '100px',
+        rr_height: '150px',
+      },
+    }))
+
+    // Simulate the image load event
+    const loadEvent = new window.Event('load');
+    img.dispatchEvent(loadEvent);
+
+    // Verify that onBlockedImageLoad was not called since the image was already complete
+    expect(onBlockedImageLoad).not.toHaveBeenCalled();
   });
 });

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -669,7 +669,8 @@ describe('image loading', () => {
     });
 
     expect(serializedNode?.type).toEqual(NodeType.Element);
-    if (serializedNode?.type === NodeType.Element) { // for typescript
+    if (serializedNode?.type === NodeType.Element) {
+      // for typescript
       expect(serializedNode?.attributes.rr_width).toBe('0px');
       expect(serializedNode?.attributes.rr_height).toBe('0px');
     }
@@ -694,7 +695,7 @@ describe('image loading', () => {
     expect(onBlockedImageLoad).toHaveBeenCalledWith(
       img,
       serializedNode,
-      mockRect
+      mockRect,
     );
   });
 
@@ -754,14 +755,16 @@ describe('image loading', () => {
       newlyAddedElement: false,
     });
 
-    expect(serializedNode).toEqual(expect.objectContaining({
-      type: 2,
-      tagName: 'img',
-      attributes: {
-        src: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
-      },
-      id: 1,
-    }))
+    expect(serializedNode).toEqual(
+      expect.objectContaining({
+        type: 2,
+        tagName: 'img',
+        attributes: {
+          src: 'data:image/gif;base64,R0lGODlhAQABAAAAACw=',
+        },
+        id: 1,
+      }),
+    );
 
     // Simulate the image load event
     const loadEvent = new window.Event('load');
@@ -839,15 +842,17 @@ describe('image loading', () => {
     });
 
     console.log(serializedNode);
-    expect(serializedNode).toEqual(expect.objectContaining({
-      type: 2,
-      tagName: 'img',
-      attributes: {
-        class: 'rr-block',
-        rr_width: '100px',
-        rr_height: '150px',
-      },
-    }))
+    expect(serializedNode).toEqual(
+      expect.objectContaining({
+        type: 2,
+        tagName: 'img',
+        attributes: {
+          class: 'rr-block',
+          rr_width: '100px',
+          rr_height: '150px',
+        },
+      }),
+    );
 
     // Simulate the image load event
     const loadEvent = new window.Event('load');

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -470,7 +470,7 @@ function record<T = eventWithTime>(
       onStylesheetLoad: (linkEl, childSn) => {
         stylesheetManager.attachLinkElement(linkEl, childSn);
       },
-      onBlockedImageLoad: (_imageEl, serializedNode, {width, height}) => {
+      onBlockedImageLoad: (_imageEl, serializedNode, { width, height }) => {
         wrappedMutationEmit({
           adds: [],
           removes: [],
@@ -485,8 +485,8 @@ function record<T = eventWithTime>(
                 },
               },
             },
-          ]
-        })
+          ],
+        });
       },
       keepIframeSrcFn,
     });

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -470,6 +470,24 @@ function record<T = eventWithTime>(
       onStylesheetLoad: (linkEl, childSn) => {
         stylesheetManager.attachLinkElement(linkEl, childSn);
       },
+      onBlockedImageLoad: (_imageEl, serializedNode, {width, height}) => {
+        wrappedMutationEmit({
+          adds: [],
+          removes: [],
+          texts: [],
+          attributes: [
+            {
+              id: serializedNode.id,
+              attributes: {
+                style: {
+                  width: `${width}px`,
+                  height: `${height}px`,
+                },
+              },
+            },
+          ]
+        })
+      },
       keepIframeSrcFn,
     });
 

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -375,6 +375,24 @@ export default class MutationBuffer {
         onStylesheetLoad: (link, childSn) => {
           this.stylesheetManager.attachLinkElement(link, childSn);
         },
+        onBlockedImageLoad: (_imageEl, serializedNode, {width, height}) => {
+          this.mutationCb({
+            adds: [],
+            removes: [],
+            texts: [],
+            attributes: [
+              {
+                id: serializedNode.id,
+                attributes: {
+                  style: {
+                    width: `${width}px`,
+                    height: `${height}px`,
+                  },
+                },
+              }
+            ]
+          })
+        },
       });
       if (sn) {
         adds.push({

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -375,7 +375,7 @@ export default class MutationBuffer {
         onStylesheetLoad: (link, childSn) => {
           this.stylesheetManager.attachLinkElement(link, childSn);
         },
-        onBlockedImageLoad: (_imageEl, serializedNode, {width, height}) => {
+        onBlockedImageLoad: (_imageEl, serializedNode, { width, height }) => {
           this.mutationCb({
             adds: [],
             removes: [],
@@ -389,9 +389,9 @@ export default class MutationBuffer {
                     height: `${height}px`,
                   },
                 },
-              }
-            ]
-          })
+              },
+            ],
+          });
         },
       });
       if (sn) {


### PR DESCRIPTION
Blocked images do not have the correct dimensions if we snapshot before the image finishes loading. This attaches an event listener to the image and creates a mutation event to set the correct width/height of the image placeholder element after the image is loaded.
