### PR TITLE
feat(replay): Manual snapshots can skip rAF

### DIFF
--- a/packages/rrweb-worker/src/_image-bitmap-data-url-worker.ts
+++ b/packages/rrweb-worker/src/_image-bitmap-data-url-worker.ts
@@ -65,7 +65,8 @@ worker.onmessage = async function (e) {
       maxCanvasSize,
     );
     const offscreen = new OffscreenCanvas(targetWidth, targetHeight);
-    const ctx = offscreen.getContext('bitmaprenderer')!;
+    const ctx = offscreen.getContext('bitmaprenderer');
+
     const resizedBitmap =
       targetWidth === width && targetHeight === height
         ? bitmap
@@ -77,7 +78,7 @@ worker.onmessage = async function (e) {
             resizeQuality: 'low',
           });
 
-    ctx.transferFromImageBitmap(resizedBitmap);
+    ctx?.transferFromImageBitmap(resizedBitmap);
     bitmap.close();
 
     const blob = await offscreen.convertToBlob(dataURLOptions); // takes a while

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -34,24 +34,6 @@ type SnapshotOptions = {
   skipRequestAnimationFrame?: boolean;
 };
 
-function preserveWebGLContext(canvas: HTMLCanvasElement): void {
-  const context = canvas.getContext((canvas as ICanvas).__context) as
-    | WebGLRenderingContext
-    | WebGL2RenderingContext
-    | null;
-
-  if (context?.getContextAttributes()?.preserveDrawingBuffer === false) {
-    // Hack to load canvas back into memory so `createImageBitmap` can grab it's contents.
-    // Context: https://twitter.com/Juice10/status/1499775271758704643
-    // Preferably we set `preserveDrawingBuffer` to true, but that's not always possible,
-    // especially when canvas is loaded before rrweb.
-    // This hack can wipe the background color of the canvas in the (unlikely) event that
-    // the canvas background was changed but clear was not called directly afterwards.
-    // Example of this hack having negative side effect: https://visgl.github.io/react-map-gl/examples/layers
-    context.clear(context.COLOR_BUFFER_BIT);
-  }
-}
-
 export interface CanvasManagerInterface {
   reset(): void;
   freeze(): void;
@@ -256,6 +238,7 @@ export class CanvasManager implements CanvasManagerInterface {
   }
 
   public snapshot(canvasElement?: HTMLCanvasElement, options?: SnapshotOptions): void {
+    console.log('snapshot');
     if (options?.skipRequestAnimationFrame) {
       this.takeSnapshot(performance.now(), true, canvasElement);
       return;
@@ -498,7 +481,21 @@ export class CanvasManager implements CanvasManagerInterface {
         !isManualSnapshot &&
         ['webgl', 'webgl2'].includes((canvas as ICanvas).__context)
       ) {
-        preserveWebGLContext(canvas);
+        const context = canvas.getContext((canvas as ICanvas).__context) as
+          | WebGLRenderingContext
+          | WebGL2RenderingContext
+          | null;
+
+        if (context?.getContextAttributes()?.preserveDrawingBuffer === false) {
+          // Hack to load canvas back into memory so `createImageBitmap` can grab it's contents.
+          // Context: https://twitter.com/Juice10/status/1499775271758704643
+          // Preferably we set `preserveDrawingBuffer` to true, but that's not always possible,
+          // especially when canvas is loaded before rrweb.
+          // This hack can wipe the background color of the canvas in the (unlikely) event that
+          // the canvas background was changed but clear was not called directly afterwards.
+          // Example of this hack having negative side effect: https://visgl.github.io/react-map-gl/examples/layers
+          context.clear(context.COLOR_BUFFER_BIT);
+        }
       }
 
       createImageBitmap(canvas)

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -237,12 +237,17 @@ export class CanvasManager implements CanvasManagerInterface {
     this.shadowDoms = new Set();
   }
 
-  public snapshot(canvasElement?: HTMLCanvasElement, options?: SnapshotOptions): void {
+  public snapshot(
+    canvasElement?: HTMLCanvasElement,
+    options?: SnapshotOptions,
+  ): void {
     if (options?.skipRequestAnimationFrame) {
       this.takeSnapshot(performance.now(), true, canvasElement);
       return;
     }
-    onRequestAnimationFrame((timestamp) => this.takeSnapshot(timestamp, true, canvasElement));
+    onRequestAnimationFrame((timestamp) =>
+      this.takeSnapshot(timestamp, true, canvasElement),
+    );
   }
 
   private initFPSWorker(): Worker {

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -309,10 +309,7 @@ export class CanvasManager implements CanvasManagerInterface {
       this.pendingCanvasMutations.set(target, []);
     }
 
-    const mutations = this.pendingCanvasMutations.get(target);
-    if (mutations) {
-      mutations.push(mutation);
-    }
+    this.pendingCanvasMutations.get(target)!.push(mutation);
   };
 
   private initCanvasFPSObserver() {

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -128,63 +128,6 @@ export class CanvasManager implements CanvasManagerInterface {
 
   private lastSnapshotTime = 0;
 
-  /**
-   * Returns all `canvas` elements that are not blocked by the given selectors. Searches all windows and shadow roots.
-   */
-  private getCanvasElements(
-    blockClass?: blockClass,
-    blockSelector?: string | null,
-    unblockSelector?: string | null,
-  ): HTMLCanvasElement[] {
-    const matchedCanvas: HTMLCanvasElement[] = [];
-
-    const searchCanvas = (root: Document | ShadowRoot) => {
-      root.querySelectorAll('canvas').forEach((canvas) => {
-        if (
-          !isBlocked(
-            canvas,
-            blockClass || 'rr-block',
-            blockSelector || null,
-            unblockSelector || null,
-            true,
-          )
-        ) {
-          matchedCanvas.push(canvas);
-        }
-      });
-    };
-
-    // Search in all windows
-    for (const item of this.windows) {
-      const window = item.deref();
-      let _document: Document | false | undefined;
-
-      try {
-        _document = window && window.document;
-      } catch {
-        // Accessing `window.document` can throw a security error:
-        // "Failed to read a named property 'document' from 'Window': An
-        // attempt was made to break through the security policy of the user
-        // agent."
-      }
-
-      if (_document) {
-        // This is not included in the `try` block above in case `searchCanvas()` throws
-        searchCanvas(_document);
-      }
-    }
-
-    // Search in shadow roots
-    for (const item of this.shadowDoms) {
-      const shadowRoot = item.deref();
-      if (shadowRoot) {
-        searchCanvas(shadowRoot);
-      }
-    }
-
-    return matchedCanvas;
-  }
-
   public reset() {
     this.pendingCanvasMutations.clear();
     this.restoreHandlers.forEach((handler) => {
@@ -253,7 +196,7 @@ export class CanvasManager implements CanvasManagerInterface {
         this.startPendingCanvasMutationFlusher();
       }
       if (recordCanvas && typeof sampling === 'number') {
-        this.initCanvasFPSObserver(false);
+        this.initCanvasFPSObserver();
       }
     })();
   }
@@ -378,11 +321,16 @@ export class CanvasManager implements CanvasManagerInterface {
     }
   };
 
-  private initCanvasFPSObserver(isManualSnapshot = false) {
+  private initCanvasFPSObserver() {
     let rafId: number;
 
+    if (!this.windows.length && !this.shadowDoms.size) {
+      // If these are empty, then we won't be able to find any canvases to snapshot, so nothing to do here.
+      return;
+    }
+
     const rafCallback = (timestamp: DOMHighResTimeStamp) => {
-      this.takeSnapshot(timestamp, isManualSnapshot);
+      this.takeSnapshot(timestamp, false);
       rafId = onRequestAnimationFrame(rafCallback);
     };
 
@@ -433,6 +381,63 @@ export class CanvasManager implements CanvasManagerInterface {
   }
 
   /**
+   * Returns all `canvas` elements that are not blocked by the given selectors. Searches all windows and shadow roots.
+   */
+  private getCanvasElements(
+    blockClass?: blockClass,
+    blockSelector?: string | null,
+    unblockSelector?: string | null,
+  ): HTMLCanvasElement[] {
+    const matchedCanvas: HTMLCanvasElement[] = [];
+
+    const searchCanvas = (root: Document | ShadowRoot) => {
+      root.querySelectorAll('canvas').forEach((canvas) => {
+        if (
+          !isBlocked(
+            canvas,
+            blockClass || 'rr-block',
+            blockSelector || null,
+            unblockSelector || null,
+            true,
+          )
+        ) {
+          matchedCanvas.push(canvas);
+        }
+      });
+    };
+
+    // Search in all windows
+    for (const item of this.windows) {
+      const window = item.deref();
+      let _document: Document | false | undefined;
+
+      try {
+        _document = window && window.document;
+      } catch {
+        // Accessing `window.document` can throw a security error:
+        // "Failed to read a named property 'document' from 'Window': An
+        // attempt was made to break through the security policy of the user
+        // agent."
+      }
+
+      if (_document) {
+        // This is not included in the `try` block above in case `searchCanvas()` throws
+        searchCanvas(_document);
+      }
+    }
+
+    // Search in shadow roots
+    for (const item of this.shadowDoms) {
+      const shadowRoot = item.deref();
+      if (shadowRoot) {
+        searchCanvas(shadowRoot);
+      }
+    }
+
+    return matchedCanvas;
+  }
+
+  /**
    * Takes a snapshot of the provided canvas element, or will search all windows/shadow roots for canvases. Will self-throttle based on `options.sampling`.
    *
    * @returns `true` if the snapshot was taken, `false` if it was throttled.
@@ -469,7 +474,7 @@ export class CanvasManager implements CanvasManagerInterface {
     canvases.forEach((canvas) => {
       const id = this.mirror.getId(canvas);
 
-      // Check is canvas is valid and not already being processed
+      // Check if canvas is valid and not already being processed
       if (
         !this.mirror.hasNode(canvas) ||
         !canvas.width ||

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -155,10 +155,10 @@ export class CanvasManager implements CanvasManagerInterface {
       recordCanvas,
       errorHandler,
     } = options;
+    options.sampling = sampling;
     this.mutationCb = options.mutationCb;
     this.mirror = options.mirror;
     this.options = options;
-    this.options.sampling = sampling;
 
     if (errorHandler) {
       registerErrorHandler(errorHandler);
@@ -375,29 +375,22 @@ export class CanvasManager implements CanvasManagerInterface {
    * Returns all `canvas` elements that are not blocked by the given selectors. Searches all windows and shadow roots.
    */
   private getCanvasElements(
-    blockClass?: blockClass,
-    blockSelector?: string | null,
-    unblockSelector?: string | null,
+    blockClass: blockClass,
+    blockSelector: string | null,
+    unblockSelector: string | null,
   ): HTMLCanvasElement[] {
     const matchedCanvas: HTMLCanvasElement[] = [];
 
     const searchCanvas = (root: Document | ShadowRoot) => {
       root.querySelectorAll('canvas').forEach((canvas) => {
         if (
-          !isBlocked(
-            canvas,
-            blockClass || 'rr-block',
-            blockSelector || null,
-            unblockSelector || null,
-            true,
-          )
+          !isBlocked(canvas, blockClass, blockSelector, unblockSelector, true)
         ) {
           matchedCanvas.push(canvas);
         }
       });
     };
 
-    // Search in all windows
     for (const item of this.windows) {
       const window = item.deref();
       let _document: Document | false | undefined;

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -442,8 +442,14 @@ export class CanvasManager implements CanvasManagerInterface {
     isManualSnapshot: boolean,
     canvasElement?: HTMLCanvasElement,
   ) {
-    const { sampling, blockClass, blockSelector, unblockSelector, dataURLOptions, maxCanvasSize } =
-      this.options;
+    const {
+      sampling,
+      blockClass,
+      blockSelector,
+      unblockSelector,
+      dataURLOptions,
+      maxCanvasSize,
+    } = this.options;
     const fps = sampling === 'all' ? 2 : sampling || 2;
     const timeBetweenSnapshots = 1000 / fps;
     const shouldThrottle =

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -30,6 +30,9 @@ type pendingCanvasMutationsMap = Map<
   canvasMutationWithType[]
 >;
 type MaxCanvasSize = [number, number];
+type SnapshotOptions = {
+  skipRequestAnimationFrame?: boolean;
+};
 
 function preserveWebGLContext(canvas: HTMLCanvasElement): void {
   const context = canvas.getContext((canvas as ICanvas).__context) as
@@ -55,7 +58,7 @@ export interface CanvasManagerInterface {
   unfreeze(): void;
   lock(): void;
   unlock(): void;
-  snapshot(canvasElement?: HTMLCanvasElement): void;
+  snapshot(canvasElement?: HTMLCanvasElement, options?: SnapshotOptions): void;
   addWindow(win: IWindow): void;
   addShadowRoot(shadowRoot: ShadowRoot): void;
   resetShadowRoots(): void;
@@ -252,8 +255,12 @@ export class CanvasManager implements CanvasManagerInterface {
     this.shadowDoms = new Set();
   }
 
-  public snapshot(canvasElement?: HTMLCanvasElement): void {
-    this.takeSnapshot(performance.now(), true, canvasElement);
+  public snapshot(canvasElement?: HTMLCanvasElement, options?: SnapshotOptions): void {
+    if (options?.skipRequestAnimationFrame) {
+      this.takeSnapshot(performance.now(), true, canvasElement);
+      return;
+    }
+    onRequestAnimationFrame((timestamp) => this.takeSnapshot(timestamp, true, canvasElement));
   }
 
   private initFPSWorker(): Worker {

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -508,6 +508,7 @@ export class CanvasManager implements CanvasManagerInterface {
         })
         .catch((error) => {
           callbackWrapper(() => {
+            this.snapshotInProgressMap.delete(id);
             throw error;
           })();
         });

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -29,6 +29,25 @@ type pendingCanvasMutationsMap = Map<
   HTMLCanvasElement,
   canvasMutationWithType[]
 >;
+type MaxCanvasSize = [number, number];
+
+function preserveWebGLContext(canvas: HTMLCanvasElement): void {
+  const context = canvas.getContext((canvas as ICanvas).__context) as
+    | WebGLRenderingContext
+    | WebGL2RenderingContext
+    | null;
+
+  if (context?.getContextAttributes()?.preserveDrawingBuffer === false) {
+    // Hack to load canvas back into memory so `createImageBitmap` can grab it's contents.
+    // Context: https://twitter.com/Juice10/status/1499775271758704643
+    // Preferably we set `preserveDrawingBuffer` to true, but that's not always possible,
+    // especially when canvas is loaded before rrweb.
+    // This hack can wipe the background color of the canvas in the (unlikely) event that
+    // the canvas background was changed but clear was not called directly afterwards.
+    // Example of this hack having negative side effect: https://visgl.github.io/react-map-gl/examples/layers
+    context.clear(context.COLOR_BUFFER_BIT);
+  }
+}
 
 export interface CanvasManagerInterface {
   reset(): void;
@@ -50,7 +69,7 @@ export interface CanvasManagerConstructorOptions {
   blockClass: blockClass;
   blockSelector: string | null;
   unblockSelector: string | null;
-  maxCanvasSize?: [number, number] | null;
+  maxCanvasSize?: MaxCanvasSize | null;
   mirror: Mirror;
   dataURLOptions: DataURLOptions;
   errorHandler?: ErrorHandler;
@@ -109,6 +128,63 @@ export class CanvasManager implements CanvasManagerInterface {
 
   private lastSnapshotTime = 0;
 
+  /**
+   * Returns all `canvas` elements that are not blocked by the given selectors. Searches all windows and shadow roots.
+   */
+  private getCanvasElements(
+    blockClass?: blockClass,
+    blockSelector?: string | null,
+    unblockSelector?: string | null,
+  ): HTMLCanvasElement[] {
+    const matchedCanvas: HTMLCanvasElement[] = [];
+
+    const searchCanvas = (root: Document | ShadowRoot) => {
+      root.querySelectorAll('canvas').forEach((canvas) => {
+        if (
+          !isBlocked(
+            canvas,
+            blockClass || 'rr-block',
+            blockSelector || null,
+            unblockSelector || null,
+            true,
+          )
+        ) {
+          matchedCanvas.push(canvas);
+        }
+      });
+    };
+
+    // Search in all windows
+    for (const item of this.windows) {
+      const window = item.deref();
+      let _document: Document | false | undefined;
+
+      try {
+        _document = window && window.document;
+      } catch {
+        // Accessing `window.document` can throw a security error:
+        // "Failed to read a named property 'document' from 'Window': An
+        // attempt was made to break through the security policy of the user
+        // agent."
+      }
+
+      if (_document) {
+        // This is not included in the `try` block above in case `searchCanvas()` throws
+        searchCanvas(_document);
+      }
+    }
+
+    // Search in shadow roots
+    for (const item of this.shadowDoms) {
+      const shadowRoot = item.deref();
+      if (shadowRoot) {
+        searchCanvas(shadowRoot);
+      }
+    }
+
+    return matchedCanvas;
+  }
+
   public reset() {
     this.pendingCanvasMutations.clear();
     this.restoreHandlers.forEach((handler) => {
@@ -145,49 +221,39 @@ export class CanvasManager implements CanvasManagerInterface {
 
   constructor(options: CanvasManagerConstructorOptions) {
     const {
+      enableManualSnapshot,
       sampling = 'all',
       win,
-      blockClass,
-      blockSelector,
-      unblockSelector,
-      maxCanvasSize,
       recordCanvas,
-      dataURLOptions,
       errorHandler,
     } = options;
     this.mutationCb = options.mutationCb;
     this.mirror = options.mirror;
     this.options = options;
+    this.options.sampling = sampling;
 
     if (errorHandler) {
       registerErrorHandler(errorHandler);
     }
     if (
       (recordCanvas && typeof sampling === 'number') ||
-      options.enableManualSnapshot
+      enableManualSnapshot
     ) {
       this.worker = this.initFPSWorker();
     }
     this.addWindow(win);
-    if (options.enableManualSnapshot) {
+
+    if (enableManualSnapshot) {
       return;
     }
+
     callbackWrapper(() => {
       if (recordCanvas && sampling === 'all') {
         this.startRAFTimestamping();
         this.startPendingCanvasMutationFlusher();
       }
       if (recordCanvas && typeof sampling === 'number') {
-        this.initCanvasFPSObserver(
-          sampling,
-          blockClass,
-          blockSelector,
-          unblockSelector,
-          maxCanvasSize,
-          {
-            dataURLOptions,
-          },
-        );
+        this.initCanvasFPSObserver(false);
       }
     })();
   }
@@ -241,6 +307,10 @@ export class CanvasManager implements CanvasManagerInterface {
 
   public resetShadowRoots() {
     this.shadowDoms = new Set();
+  }
+
+  public snapshot(canvasElement?: HTMLCanvasElement): void {
+    this.takeSnapshot(performance.now(), true, canvasElement);
   }
 
   private initFPSWorker(): Worker {
@@ -302,31 +372,26 @@ export class CanvasManager implements CanvasManagerInterface {
       this.pendingCanvasMutations.set(target, []);
     }
 
-    this.pendingCanvasMutations.get(target)!.push(mutation);
+    const mutations = this.pendingCanvasMutations.get(target);
+    if (mutations) {
+      mutations.push(mutation);
+    }
   };
 
-  private initCanvasFPSObserver(
-    fps: number,
-    blockClass: blockClass,
-    blockSelector: string | null,
-    unblockSelector: string | null,
-    maxCanvasSize: [number, number] | null | undefined,
-    options: {
-      dataURLOptions: DataURLOptions;
-    },
-  ) {
-    const rafId = this.takeSnapshot(
-      false,
-      fps,
-      blockClass,
-      blockSelector,
-      unblockSelector,
-      maxCanvasSize,
-      options.dataURLOptions,
-    );
+  private initCanvasFPSObserver(isManualSnapshot = false) {
+    let rafId: number;
+
+    const rafCallback = (timestamp: DOMHighResTimeStamp) => {
+      this.takeSnapshot(timestamp, isManualSnapshot);
+      rafId = onRequestAnimationFrame(rafCallback);
+    };
+
+    rafId = onRequestAnimationFrame(rafCallback);
 
     this.restoreHandlers.push(() => {
-      cancelAnimationFrame(rafId);
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+      }
     });
   }
 
@@ -367,164 +432,79 @@ export class CanvasManager implements CanvasManagerInterface {
     });
   }
 
-  public snapshot(canvasElement?: HTMLCanvasElement) {
-    const { options } = this;
-    const rafId = this.takeSnapshot(
-      true,
-      options.sampling === 'all' ? 2 : options.sampling || 2,
-      options.blockClass,
-      options.blockSelector,
-      options.unblockSelector,
-      options.maxCanvasSize,
-      options.dataURLOptions,
-      canvasElement,
-    );
-
-    this.restoreHandlers.push(() => {
-      cancelAnimationFrame(rafId);
-    });
-  }
-
+  /**
+   * Takes a snapshot of the provided canvas element, or will search all windows/shadow roots for canvases. Will self-throttle based on `options.sampling`.
+   *
+   * @returns `true` if the snapshot was taken, `false` if it was throttled.
+   */
   private takeSnapshot(
+    timestamp: DOMHighResTimeStamp,
     isManualSnapshot: boolean,
-    fps: number,
-    blockClass: blockClass,
-    blockSelector: string | null,
-    unblockSelector: string | null,
-    maxCanvasSize: [number, number] | null | undefined,
-    dataURLOptions: DataURLOptions,
     canvasElement?: HTMLCanvasElement,
   ) {
+    const { sampling, blockClass, blockSelector, unblockSelector, dataURLOptions, maxCanvasSize } =
+      this.options;
+    const fps = sampling === 'all' ? 2 : sampling || 2;
     const timeBetweenSnapshots = 1000 / fps;
-    let rafId: number;
+    const shouldThrottle =
+      this.lastSnapshotTime &&
+      timestamp - this.lastSnapshotTime < timeBetweenSnapshots;
 
-    const getCanvas = (
-      canvasElement?: HTMLCanvasElement,
-    ): HTMLCanvasElement[] => {
-      if (canvasElement) {
-        return [canvasElement];
-      }
+    if (shouldThrottle) {
+      return false;
+    }
 
-      const matchedCanvas: HTMLCanvasElement[] = [];
+    this.lastSnapshotTime = timestamp;
+    const canvases = canvasElement
+      ? [canvasElement]
+      : this.getCanvasElements(blockClass, blockSelector, unblockSelector);
 
-      const searchCanvas = (root: Document | ShadowRoot) => {
-        root.querySelectorAll('canvas').forEach((canvas) => {
-          if (
-            !isBlocked(canvas, blockClass, blockSelector, unblockSelector, true)
-          ) {
-            matchedCanvas.push(canvas);
-          }
-        });
-      };
+    // Process all canvases concurrently
+    canvases.forEach((canvas) => {
+      const id = this.mirror.getId(canvas);
 
-      for (const item of this.windows) {
-        const window = item.deref();
-        let _document: Document | false | undefined;
-
-        try {
-          _document = window && window.document;
-        } catch {
-          // Accesing `window.document` can throw a security error:
-          // "Failed to read a named property 'document' from 'Window': An
-          // attempt was made to break through the security policy of the user
-          // agent."
-        }
-
-        if (_document) {
-          // This is not included in the `try` block above in case `searchCanvas()` throws
-          searchCanvas(_document);
-        }
-      }
-
-      for (const item of this.shadowDoms) {
-        const shadowRoot = item.deref();
-        if (shadowRoot) {
-          searchCanvas(shadowRoot);
-        }
-      }
-      return matchedCanvas;
-    };
-
-    const takeCanvasSnapshots = (timestamp: DOMHighResTimeStamp) => {
-      if (!this.windows.length) {
-        // exit loop if windows list is empty
-        return;
-      }
+      // Check is canvas is valid and not already being processed
       if (
-        this.lastSnapshotTime &&
-        timestamp - this.lastSnapshotTime < timeBetweenSnapshots
+        !this.mirror.hasNode(canvas) ||
+        !canvas.width ||
+        !canvas.height ||
+        this.snapshotInProgressMap.get(id)
       ) {
-        rafId = onRequestAnimationFrame(takeCanvasSnapshots);
         return;
       }
-      this.lastSnapshotTime = timestamp;
 
-      getCanvas(canvasElement).forEach((canvas: HTMLCanvasElement) => {
-        if (!this.mirror.hasNode(canvas)) {
-          return;
-        }
-        const id = this.mirror.getId(canvas);
-        if (this.snapshotInProgressMap.get(id)) return;
+      this.snapshotInProgressMap.set(id, true);
 
-        // Don't do anything if canvas height/width is 0, otherwise causes
-        // `createImageBitmap()` to throw
-        if (!canvas.width || !canvas.height) return;
-
-        this.snapshotInProgressMap.set(id, true);
-        if (
-          !isManualSnapshot &&
-          ['webgl', 'webgl2'].includes((canvas as ICanvas).__context)
-        ) {
-          // if the canvas hasn't been modified recently,
-          // its contents won't be in memory and `createImageBitmap`
-          // will return a transparent imageBitmap
-
-          const context = canvas.getContext((canvas as ICanvas).__context) as
-            | WebGLRenderingContext
-            | WebGL2RenderingContext
-            | null;
-          if (
-            context?.getContextAttributes()?.preserveDrawingBuffer === false
-          ) {
-            // Hack to load canvas back into memory so `createImageBitmap` can grab it's contents.
-            // Context: https://twitter.com/Juice10/status/1499775271758704643
-            // Preferably we set `preserveDrawingBuffer` to true, but that's not always possible,
-            // especially when canvas is loaded before rrweb.
-            // This hack can wipe the background color of the canvas in the (unlikely) event that
-            // the canvas background was changed but clear was not called directly afterwards.
-            // Example of this hack having negative side effect: https://visgl.github.io/react-map-gl/examples/layers
-            context.clear(context.COLOR_BUFFER_BIT);
-          }
-        }
-
-        createImageBitmap(canvas)
-          .then((bitmap) => {
-            this.worker?.postMessage(
-              {
-                id,
-                bitmap,
-                width: canvas.width,
-                height: canvas.height,
-                dataURLOptions,
-                maxCanvasSize,
-              },
-              [bitmap],
-            );
-          })
-          .catch((error) => {
-            callbackWrapper(() => {
-              throw error;
-            })();
-          });
-      });
-
-      if (!isManualSnapshot) {
-        rafId = onRequestAnimationFrame(takeCanvasSnapshots);
+      // Handle WebGL context preservation
+      if (
+        !isManualSnapshot &&
+        ['webgl', 'webgl2'].includes((canvas as ICanvas).__context)
+      ) {
+        preserveWebGLContext(canvas);
       }
-    };
 
-    rafId = onRequestAnimationFrame(takeCanvasSnapshots);
-    return rafId;
+      createImageBitmap(canvas)
+        .then((bitmap) => {
+          this.worker?.postMessage(
+            {
+              id,
+              bitmap,
+              width: canvas.width,
+              height: canvas.height,
+              dataURLOptions,
+              maxCanvasSize,
+            },
+            [bitmap],
+          );
+        })
+        .catch((error) => {
+          callbackWrapper(() => {
+            throw error;
+          })();
+        });
+    });
+
+    return true;
   }
 
   private startPendingCanvasMutationFlusher() {

--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -238,7 +238,6 @@ export class CanvasManager implements CanvasManagerInterface {
   }
 
   public snapshot(canvasElement?: HTMLCanvasElement, options?: SnapshotOptions): void {
-    console.log('snapshot');
     if (options?.skipRequestAnimationFrame) {
       this.takeSnapshot(performance.now(), true, canvasElement);
       return;


### PR DESCRIPTION
Adds an option to `snapshot()` to skip rAF. This should fix some cases where manual snapshots were not able to capture the canvas buffer.

Also cleans up the code a bit and fixes the `initCanvasFPSObserver` so we can properly clean-up the recording loop.
