### PR TITLE
fix(rrweb): Do not call setAttribute on TEXT nodes 

### DIFF
--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1951,10 +1951,15 @@ export class Replayer {
                   // for safe
                 }
               }
-              (target as Element | RRElement).setAttribute(
-                attributeName,
-                value,
-              );
+              // Not sure yet how this is happening during recording, but this
+              // prevents calling `setAttribute` on Text nodes (which does not
+              // have `setAttribute` method).
+              if (target.nodeType !== 3) {
+                (target as Element | RRElement).setAttribute(
+                  attributeName,
+                  value,
+                );
+              }
             } catch (error) {
               this.warn(
                 'An error occurred may due to the checkout feature.',


### PR DESCRIPTION
Not sure yet how this is happening during recording, but prevent player from calling `setAttribute` on TEXT nodes (which does not have that method). This additionally prevents the player from freezing while trying to process these invalid mutations.