### PR TITLE
feat(replay): catch rejections from `play()`

### DIFF
--- a/packages/rrdom/src/diff.ts
+++ b/packages/rrdom/src/diff.ts
@@ -241,22 +241,26 @@ function diffAfterUpdatingChildren(
           const oldMediaElement = oldTree as HTMLMediaElement;
           const newMediaRRElement = newRRElement as unknown as RRMediaElement;
           if (newMediaRRElement.paused !== undefined) {
-            newMediaRRElement.paused
-              ? void oldMediaElement.pause()
-              : void oldMediaElement.play().catch((e) => {
-                  console.warn(e);
-                  // ignore rejections from play() as they are not useful and
-                  // quite noisy. some examples:
-                  // AbortError: The play() request was interrupted by a call to pause(). https://goo.gl/LdLk22
-                  // AbortError: The play() request was interrupted by a new load request. https://goo.gl/LdLk22
-                  // AbortError: The play() request was interrupted by a call to pause().
-                  // NotAllowedError: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD
-                  // AbortError: The play() request was interrupted because the media was removed from the document.
-                  // AbortError: The play() request was interrupted because video-only background media was paused to save power. https://goo.gl/LdLk22
-                  // NotAllowedError: play() failed because the user didn't interact with the document first.
-                  // NotAllowedError: play() can only be initiated by a user gesture.
-                  // AbortError: The play() request was interrupted by end of playback. https://goo.gl/LdLk22
-                });
+            const maybePromise = newMediaRRElement.paused
+              ? oldMediaElement.pause()
+              : oldMediaElement.play();
+
+            if (typeof maybePromise?.catch === 'function') {
+              maybePromise.catch((e) => {
+                console.warn(e);
+                // ignore rejections from play() as they are not useful and
+                // quite noisy. some examples:
+                // AbortError: The play() request was interrupted by a call to pause(). https://goo.gl/LdLk22
+                // AbortError: The play() request was interrupted by a new load request. https://goo.gl/LdLk22
+                // AbortError: The play() request was interrupted by a call to pause().
+                // NotAllowedError: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD
+                // AbortError: The play() request was interrupted because the media was removed from the document.
+                // AbortError: The play() request was interrupted because video-only background media was paused to save power. https://goo.gl/LdLk22
+                // NotAllowedError: play() failed because the user didn't interact with the document first.
+                // NotAllowedError: play() can only be initiated by a user gesture.
+                // AbortError: The play() request was interrupted by end of playback. https://goo.gl/LdLk22
+              });
+            }
           }
           if (newMediaRRElement.muted !== undefined)
             oldMediaElement.muted = newMediaRRElement.muted;

--- a/packages/rrdom/src/diff.ts
+++ b/packages/rrdom/src/diff.ts
@@ -240,10 +240,24 @@ function diffAfterUpdatingChildren(
         case 'VIDEO': {
           const oldMediaElement = oldTree as HTMLMediaElement;
           const newMediaRRElement = newRRElement as unknown as RRMediaElement;
-          if (newMediaRRElement.paused !== undefined)
+          if (newMediaRRElement.paused !== undefined) {
             newMediaRRElement.paused
               ? void oldMediaElement.pause()
-              : void oldMediaElement.play();
+              : void oldMediaElement.play().catch((e) => {
+                  console.warn(e);
+                  // ignore rejections from play() as they are not useful and
+                  // quite noisy. some examples:
+                  // AbortError: The play() request was interrupted by a call to pause(). https://goo.gl/LdLk22
+                  // AbortError: The play() request was interrupted by a new load request. https://goo.gl/LdLk22
+                  // AbortError: The play() request was interrupted by a call to pause().
+                  // NotAllowedError: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD
+                  // AbortError: The play() request was interrupted because the media was removed from the document.
+                  // AbortError: The play() request was interrupted because video-only background media was paused to save power. https://goo.gl/LdLk22
+                  // NotAllowedError: play() failed because the user didn't interact with the document first.
+                  // NotAllowedError: play() can only be initiated by a user gesture.
+                  // AbortError: The play() request was interrupted by end of playback. https://goo.gl/LdLk22
+                });
+          }
           if (newMediaRRElement.muted !== undefined)
             oldMediaElement.muted = newMediaRRElement.muted;
           if (newMediaRRElement.volume !== undefined)

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1462,7 +1462,7 @@ export class Replayer {
             // unexpeted behavior
             const maybePlayPromise = mediaEl.play();
 
-            if (typeof maybePlayPromise?.then === 'function') {
+            if (typeof maybePlayPromise?.catch === 'function') {
               maybePlayPromise.catch((err) => {
                 // ignore rejections from play() as they are not useful and
                 // quite noisy. some examples:

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -1460,7 +1460,24 @@ export class Replayer {
             // i.e. media will evntualy start to play when data is loaded
             // 'canplay' event fires even when currentTime attribute changes which may lead to
             // unexpeted behavior
-            void mediaEl.play();
+            const maybePlayPromise = mediaEl.play();
+
+            if (typeof maybePlayPromise?.then === 'function') {
+              maybePlayPromise.catch((err) => {
+                // ignore rejections from play() as they are not useful and
+                // quite noisy. some examples:
+                // AbortError: The play() request was interrupted by a call to pause(). https://goo.gl/LdLk22
+                // AbortError: The play() request was interrupted by a new load request. https://goo.gl/LdLk22
+                // AbortError: The play() request was interrupted by a call to pause().
+                // NotAllowedError: play() failed because the user didn't interact with the document first. https://goo.gl/xX8pDD
+                // AbortError: The play() request was interrupted because the media was removed from the document.
+                // AbortError: The play() request was interrupted because video-only background media was paused to save power. https://goo.gl/LdLk22
+                // NotAllowedError: play() failed because the user didn't interact with the document first.
+                // NotAllowedError: play() can only be initiated by a user gesture.
+                // AbortError: The play() request was interrupted by end of playback. https://goo.gl/LdLk22
+                console.warn(err);
+              });
+            }
           }
           if (d.type === MediaInteractions.RateChange) {
             mediaEl.playbackRate = d.playbackRate;


### PR DESCRIPTION
We have a lot of noisy issues in Sentry due to calling `play()` on videos during replays. This PR catches rejections from `play()` and logs to console.
