### PR TITLE
chore: Rename code style check action

### DIFF
--- a/.github/workflows/style-check-v2.yml
+++ b/.github/workflows/style-check-v2.yml
@@ -1,4 +1,4 @@
-name: Code Style Check
+name: Code Style Check v2
 
 on: [push, pull_request_target]
 


### PR DESCRIPTION
This re-enables the code style check action. A repository admin disabled the action with the old name. #259 contains a fix for the old action.

This follow-up PR gives the fixed action a new name so it runs again.

Re-enabling the action will introduce a security issue, so it's better to give it a new name so it can still be used if necessary.