### PR TITLE
fix: ignore customElements.define exceptions so that it does not break replays

### DIFF
--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -166,6 +166,7 @@ function buildNode(
               class extends doc.defaultView.HTMLElement {},
             );
           } catch (e) {
+            console.warn('Cannot define custom element', e);
             // Some elements (e.g. Electron's <webview>) are registered as custom
             // elements but have names that are not valid for customElements.define()
             // (missing hyphen). Silently ignore — the element will be created as

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -160,10 +160,17 @@ function buildNode(
           // If the custom element hasn't been defined yet
           !doc.defaultView.customElements.get(n.tagName)
         )
-          doc.defaultView.customElements.define(
-            n.tagName,
-            class extends doc.defaultView.HTMLElement {},
-          );
+          try {
+            doc.defaultView.customElements.define(
+              n.tagName,
+              class extends doc.defaultView.HTMLElement {},
+            );
+          } catch (e) {
+            // Some elements (e.g. Electron's <webview>) are registered as custom
+            // elements but have names that are not valid for customElements.define()
+            // (missing hyphen). Silently ignore — the element will be created as
+            // an HTMLUnknownElement instead.
+          }
         node = doc.createElement(tagName);
       }
       /**

--- a/packages/rrweb-snapshot/test/rebuild.test.ts
+++ b/packages/rrweb-snapshot/test/rebuild.test.ts
@@ -189,6 +189,53 @@ describe('rebuild', function () {
     });
   });
 
+  describe('isCustom elements', function () {
+    it('should not throw when rebuilding custom element without hyphen (e.g. webview)', function () {
+      // Elements like Electron's <webview> are registered as custom elements
+      // but their names don't contain a hyphen, which makes them invalid for
+      // customElements.define(). We should handle this gracefully via try/catch.
+      expect(() => {
+        buildNodeWithSN(
+          {
+            id: 1,
+            tagName: 'webview',
+            type: NodeType.Element,
+            attributes: {},
+            childNodes: [],
+            isCustom: true,
+          },
+          {
+            doc: document,
+            mirror,
+            hackCss: false,
+            cache,
+          },
+        );
+      }).not.toThrow();
+    });
+
+    it('should define a custom element with a valid hyphenated name', function () {
+      const node = buildNodeWithSN(
+        {
+          id: 1,
+          tagName: 'my-component',
+          type: NodeType.Element,
+          attributes: {},
+          childNodes: [],
+          isCustom: true,
+        },
+        {
+          doc: document,
+          mirror,
+          hackCss: false,
+          cache,
+        },
+      ) as HTMLElement;
+      expect(node).toBeTruthy();
+      expect(node.tagName.toLowerCase()).toBe('my-component');
+    });
+  });
+
   // sentry: skipped because we've removed `adaptCssForReplay` for now
   // it('should not incorrectly interpret escaped quotes', () => {
   //   // the ':hover' in the below is a decoy which is not part of the selector,


### PR DESCRIPTION
Some elements (e.g. Electron `<webview>`) are registered as custom
elements but have names that are not valid for customElements.define()
(missing hyphen). Silently ignore — the element will be created as
an HTMLUnknownElement instead.
