### PR TITLE
fix: Wrap iframe contentWindow access in try-catch

### DIFF
--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/src/index.ts
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/src/index.ts
@@ -4,6 +4,7 @@ import type {
   RecordPlugin,
   ICrossOriginIframeMirror,
 } from '@sentry-internal/rrweb-types';
+import { getIFrameContentWindow } from '@sentry-internal/rrdom';
 import type { WebRTCDataChannel } from './types';
 
 export const PLUGIN_NAME = 'rrweb/canvas-webrtc@1';
@@ -248,7 +249,7 @@ export class RRWebPluginCanvasWebRTCRecord {
       if (remoteId === -1) return;
 
       found = true;
-      iframe.contentWindow?.postMessage(
+      getIFrameContentWindow(iframe)?.postMessage(
         {
           type: 'rrweb-canvas-webrtc',
           data: {

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -29,7 +29,8 @@ import {
   shouldMaskInput,
   setTimeout,
   clearTimeout,
-  getIframeContentDocument,
+  getIFrameContentDocument,
+  getIFrameContentWindow,
 } from './utils';
 
 let _id = 1;
@@ -521,7 +522,7 @@ function onceIframeLoaded(
   listener: () => unknown,
   iframeLoadTimeout: number,
 ) {
-  const win = iframeEl.contentWindow;
+  const win = getIFrameContentWindow(iframeEl);
   if (!win) {
     return;
   }
@@ -1099,7 +1100,7 @@ function serializeElementNode(
   if (tagName === 'iframe' && !keepIframeSrcFn(attributes.src as string)) {
     // Don't try to access `contentDocument` if iframe is blocked, otherwise it
     // will trigger browser warnings.
-    if (!needBlock && !getIframeContentDocument(n as HTMLIFrameElement)) {
+    if (!needBlock && !getIFrameContentDocument(n as HTMLIFrameElement)) {
       // we can't record it directly as we can't see into it
       // preserve the src attribute so a decision can be taken at replay time
       attributes.rr_src = attributes.src;
@@ -1447,7 +1448,7 @@ export function serializeNodeWithId(
     onceIframeLoaded(
       n as HTMLIFrameElement,
       () => {
-        const iframeDoc = getIframeContentDocument(n as HTMLIFrameElement);
+        const iframeDoc = getIFrameContentDocument(n as HTMLIFrameElement);
         if (iframeDoc && onIframeLoad) {
           const serializedIframeNode = serializeNodeWithId(iframeDoc, {
             doc: iframeDoc,

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -496,10 +496,23 @@ export function clearTimeout(
  * Get the content document of an iframe.
  * Catching errors is necessary because some older browsers block access to the content document of a sandboxed iframe.
  */
-export function getIframeContentDocument(iframe?: HTMLIFrameElement) {
+export function getIFrameContentDocument(iframe?: HTMLIFrameElement) {
   try {
     return (iframe as HTMLIFrameElement).contentDocument;
-  } catch (e) {
+  } catch {
+    // noop
+  }
+}
+
+/**
+ * Get the content window of an iframe.
+ * Catching errors is necessary because iOS 18.5 Safari WebView throws SecurityError
+ * when accessing contentWindow on cross-origin iframes (instead of returning null).
+ */
+export function getIFrameContentWindow(iframe?: HTMLIFrameElement) {
+  try {
+    return (iframe as HTMLIFrameElement).contentWindow;
+  } catch {
     // noop
   }
 }

--- a/packages/rrweb-snapshot/test/utils.test.ts
+++ b/packages/rrweb-snapshot/test/utils.test.ts
@@ -3,7 +3,12 @@
  */
 import { describe, it, test, expect } from 'vitest';
 import { NodeType, serializedNode } from '../src/types';
-import { extractFileExtension, isNodeMetaEqual } from '../src/utils';
+import {
+  extractFileExtension,
+  isNodeMetaEqual,
+  getIFrameContentDocument,
+  getIFrameContentWindow,
+} from '../src/utils';
 import type { serializedNodeWithId } from '@sentry-internal/rrweb-snapshot';
 
 describe('utils', () => {
@@ -197,6 +202,58 @@ describe('utils', () => {
       const path = 'https://example.com/scripts/app.min.js?version=1.0';
       const extension = extractFileExtension(path);
       expect(extension).toBe('js');
+    });
+  });
+
+  describe('getIFrameContentDocument', () => {
+    it('should return contentDocument for same-origin iframe', () => {
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      const doc = getIFrameContentDocument(iframe);
+      expect(doc).toBe(iframe.contentDocument);
+      document.body.removeChild(iframe);
+    });
+
+    it('should return undefined when accessing contentDocument throws', () => {
+      const iframe = {
+        get contentDocument(): Document {
+          throw new DOMException('Blocked', 'SecurityError');
+        },
+      } as HTMLIFrameElement;
+      const doc = getIFrameContentDocument(iframe);
+      expect(doc).toBeUndefined();
+    });
+
+    it('should return undefined for undefined input', () => {
+      const doc = getIFrameContentDocument(undefined);
+      expect(doc).toBeUndefined();
+    });
+  });
+
+  describe('getIFrameContentWindow', () => {
+    it('should return contentWindow for same-origin iframe', () => {
+      const iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      const win = getIFrameContentWindow(iframe);
+      expect(win).toBe(iframe.contentWindow);
+      document.body.removeChild(iframe);
+    });
+
+    it('should return undefined when accessing contentWindow throws', () => {
+      // Simulate iOS 18.5 Safari WebView behavior where accessing
+      // contentWindow on cross-origin iframes throws SecurityError
+      const iframe = {
+        get contentWindow(): Window {
+          throw new DOMException('Blocked', 'SecurityError');
+        },
+      } as HTMLIFrameElement;
+      const win = getIFrameContentWindow(iframe);
+      expect(win).toBeUndefined();
+    });
+
+    it('should return undefined for undefined input', () => {
+      const win = getIFrameContentWindow(undefined);
+      expect(win).toBeUndefined();
     });
   });
 });

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -12,7 +12,10 @@ import type {
   mutationCallBack,
 } from '@sentry-internal/rrweb-types';
 import type { StylesheetManager } from './stylesheet-manager';
-import { getIFrameContentDocument } from '@sentry-internal/rrdom';
+import {
+  getIFrameContentDocument,
+  getIFrameContentWindow,
+} from '@sentry-internal/rrdom';
 
 export interface IframeManagerInterface {
   crossOriginIframeMirror: CrossOriginIframeMirror;
@@ -83,8 +86,8 @@ export class IframeManager implements IframeManagerInterface {
 
   public addIframe(iframeEl: HTMLIFrameElement) {
     this.iframes.set(iframeEl, true);
-    if (iframeEl.contentWindow)
-      this.crossOriginIframeMap.set(iframeEl.contentWindow, iframeEl);
+    const contentWindow = getIFrameContentWindow(iframeEl);
+    if (contentWindow) this.crossOriginIframeMap.set(contentWindow, iframeEl);
   }
 
   public addLoadListener(cb: (iframeEl: HTMLIFrameElement) => unknown) {
@@ -110,11 +113,12 @@ export class IframeManager implements IframeManagerInterface {
     });
 
     // Receive messages (events) coming from cross-origin iframes that are nested in this same-origin iframe.
-    if (this.recordCrossOriginIframes)
-      iframeEl.contentWindow?.addEventListener(
+    if (this.recordCrossOriginIframes) {
+      getIFrameContentWindow(iframeEl)?.addEventListener(
         'message',
         this.handleMessage.bind(this),
       );
+    }
 
     this.loadListener?.(iframeEl);
 

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -4,6 +4,7 @@ import {
   SlimDOMOptions,
   createMirror,
 } from '@sentry-internal/rrweb-snapshot';
+import { getIFrameContentWindow } from '@sentry-internal/rrdom';
 import { initObservers, mutationBuffers } from './observer';
 import {
   on,
@@ -463,8 +464,9 @@ function record<T = eventWithTime>(
       },
       onIframeLoad: (iframe, childSn) => {
         iframeManager.attachIframe(iframe, childSn);
-        if (iframe.contentWindow) {
-          canvasManager.addWindow(iframe.contentWindow as IWindow);
+        const contentWindow = getIFrameContentWindow(iframe);
+        if (contentWindow) {
+          canvasManager.addWindow(contentWindow as IWindow);
         }
         shadowDomManager.observeAttachShadow(iframe);
       },

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -35,7 +35,10 @@ import {
   getShadowHost,
   closestElementOfNode,
 } from '../utils';
-import { getIFrameContentDocument } from '@sentry-internal/rrdom';
+import {
+  getIFrameContentDocument,
+  getIFrameContentWindow,
+} from '@sentry-internal/rrdom';
 
 type DoubleLinkedListNode = {
   previous: DoubleLinkedListNode | null;
@@ -369,8 +372,9 @@ export default class MutationBuffer {
           }
 
           this.iframeManager.attachIframe(iframe, childSn);
-          if (iframe.contentWindow) {
-            this.canvasManager.addWindow(iframe.contentWindow as IWindow);
+          const contentWindow = getIFrameContentWindow(iframe);
+          if (contentWindow) {
+            this.canvasManager.addWindow(contentWindow as IWindow);
           }
           this.shadowDomManager.observeAttachShadow(iframe);
         },


### PR DESCRIPTION
This PR adds a `getIFrameContentWindow()` helper that wraps accessing
iframe.contentWindow in a try-cach to prevent potential SecurityErrors when
accessing it directly (issue on Safari).

While I was not able to reproduce this error, the helper mirrors our pattern for
`getIframeContentDocument`.

Closes: #262