### PR TITLE
Add isNativeFunction fast path to getImplementation

### DIFF
--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -442,6 +442,15 @@ interface CacheableImplementations {
 
 const cachedImplementations: Partial<CacheableImplementations> = {};
 
+function isNativeFunction(func: unknown): boolean {
+  return (
+    typeof func === 'function' &&
+    /^function\s+\w+\(\)\s+\{\s+\[native code\]\s+\}$/.test(
+      func.toString(),
+    )
+  );
+}
+
 function getImplementation<T extends keyof CacheableImplementations>(
   name: T,
 ): CacheableImplementations[T] {
@@ -450,8 +459,18 @@ function getImplementation<T extends keyof CacheableImplementations>(
     return cached;
   }
 
+  const impl = window[name] as CacheableImplementations[T];
+
+  // Fast path to avoid DOM I/O — matches the approach used in
+  // @sentry-internal/browser-utils getNativeImplementation.
+  if (isNativeFunction(impl)) {
+    return (cachedImplementations[name] = impl.bind(
+      window,
+    ) as CacheableImplementations[T]);
+  }
+
+  let sandboxImpl = impl;
   const document = window.document;
-  let impl = window[name] as CacheableImplementations[T];
   if (document && typeof document.createElement === 'function') {
     try {
       const sandbox = document.createElement('iframe');
@@ -459,7 +478,7 @@ function getImplementation<T extends keyof CacheableImplementations>(
       document.head.appendChild(sandbox);
       const contentWindow = sandbox.contentWindow;
       if (contentWindow && contentWindow[name]) {
-        impl =
+        sandboxImpl =
           // eslint-disable-next-line @typescript-eslint/unbound-method
           contentWindow[name] as CacheableImplementations[T];
       }
@@ -469,7 +488,7 @@ function getImplementation<T extends keyof CacheableImplementations>(
     }
   }
 
-  return (cachedImplementations[name] = impl.bind(
+  return (cachedImplementations[name] = sandboxImpl.bind(
     window,
   ) as CacheableImplementations[T]);
 }

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -627,6 +627,15 @@ interface CacheableImplementations {
 
 const cachedImplementations: Partial<CacheableImplementations> = {};
 
+function isNativeFunction(func: unknown): boolean {
+  return (
+    typeof func === 'function' &&
+    /^function\s+\w+\(\)\s+\{\s+\[native code\]\s+\}$/.test(
+      func.toString(),
+    )
+  );
+}
+
 function getImplementation<T extends keyof CacheableImplementations>(
   name: T,
 ): CacheableImplementations[T] {
@@ -635,8 +644,18 @@ function getImplementation<T extends keyof CacheableImplementations>(
     return cached;
   }
 
+  const impl = window[name] as CacheableImplementations[T];
+
+  // Fast path to avoid DOM I/O — matches the approach used in
+  // @sentry-internal/browser-utils getNativeImplementation.
+  if (isNativeFunction(impl)) {
+    return (cachedImplementations[name] = impl.bind(
+      window,
+    ) as CacheableImplementations[T]);
+  }
+
+  let sandboxImpl = impl;
   const document = window.document;
-  let impl = window[name] as CacheableImplementations[T];
   if (document && typeof document.createElement === 'function') {
     try {
       const sandbox = document.createElement('iframe');
@@ -644,7 +663,7 @@ function getImplementation<T extends keyof CacheableImplementations>(
       document.head.appendChild(sandbox);
       const contentWindow = sandbox.contentWindow;
       if (contentWindow && contentWindow[name]) {
-        impl =
+        sandboxImpl =
           // eslint-disable-next-line @typescript-eslint/unbound-method
           contentWindow[name] as CacheableImplementations[T];
       }
@@ -654,7 +673,7 @@ function getImplementation<T extends keyof CacheableImplementations>(
     }
   }
 
-  return (cachedImplementations[name] = impl.bind(
+  return (cachedImplementations[name] = sandboxImpl.bind(
     window,
   ) as CacheableImplementations[T]);
 }


### PR DESCRIPTION
## Summary

  Add a fast path to `getImplementation()` in both `rrweb` and `rrweb-snapshot` that skips the sandbox iframe when `window[name]` is already a native browser function.

  This matches the approach already used in `@sentry-internal/browser-utils` [`getNativeImplementation`](https://github.com/getsentry/sentry-javascript/blob/10.46.0/packages/browser-utils/src/getNativeImplementation.ts#L37-L40), but was missing from the two duplicated copies inside rrweb.

 ## Problem

  `getImplementation()` unconditionally creates a hidden `<iframe>`, pulls `setTimeout` / `clearTimeout` / `requestAnimationFrame` from its `contentWindow`, caches the reference with `.bind(window)`, then removes the iframe from the DOM.

  When the implementation on `window` is already native (the common case outside Angular/Zone.js), the iframe round-trip is pure overhead. Worse, it actively breaks in Firefox when combined with tools that patch timer globals (e.g. Playwright `clock.install()`): the cached function is bound to a destroyed iframe's execution context, and Firefox throws `NS_ERROR_NOT_INITIALIZED` on the next call.

  See https://github.com/microsoft/playwright/issues/40116 for the full reproduction and discussion. I believe it should be fixed in playwright but maintainer of it thinks differently. These changes allows at least to workaround this problem mimicking playwright overrides as native functions (basically patching `toString`) and not creating iframes in this case.