### PR TITLE
fix(web-extension): bump react-router-dom and nanoid

### DIFF
--- a/packages/web-extension/package.json
+++ b/packages/web-extension/package.json
@@ -39,10 +39,10 @@
     "framer-motion": "^7.3.6",
     "idb": "^7.1.1",
     "mitt": "^3.0.0",
-    "nanoid": "^4.0.0",
+    "nanoid": "^5.0.9",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",
-    "react-router-dom": "^6.4.1"
+    "react-router-dom": "^6.30.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1386,10 +1386,10 @@
     tar-fs "^3.1.1"
     yargs "^17.7.2"
 
-"@remix-run/router@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.21.0.tgz#c65ae4262bdcfe415dbd4f64ec87676e4a56e2b5"
-  integrity sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==
+"@remix-run/router@1.23.2":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
+  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
 
 "@rollup/plugin-commonjs@^28.0.2":
   version "28.0.2"
@@ -6006,10 +6006,10 @@ nanoid@^3.3.6, nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
 
-nanoid@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
-  integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
+nanoid@^5.0.9:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.9.tgz#aac959acf7d685269fb1be7f70a90d9db0848948"
+  integrity sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==
 
 nanospinner@^1.1.0:
   version "1.2.2"
@@ -6742,20 +6742,20 @@ react-remove-scroll@^2.5.7:
     use-callback-ref "^1.3.3"
     use-sidecar "^1.1.2"
 
-react-router-dom@^6.4.1:
-  version "6.28.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.28.0.tgz#f73ebb3490e59ac9f299377062ad1d10a9f579e6"
-  integrity sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==
+react-router-dom@^6.30.2:
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.3.tgz#42ae6dc4c7158bfb0b935f162b9621b29dddf740"
+  integrity sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==
   dependencies:
-    "@remix-run/router" "1.21.0"
-    react-router "6.28.0"
+    "@remix-run/router" "1.23.2"
+    react-router "6.30.3"
 
-react-router@6.28.0:
-  version "6.28.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.28.0.tgz#29247c86d7ba901d7e5a13aa79a96723c3e59d0d"
-  integrity sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==
+react-router@6.30.3:
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
+  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
   dependencies:
-    "@remix-run/router" "1.21.0"
+    "@remix-run/router" "1.23.2"
 
 react-style-singleton@^2.2.1, react-style-singleton@^2.2.2:
   version "2.2.3"


### PR DESCRIPTION
## Summary
- Bumps `react-router-dom` from `^6.4.1` to `^6.30.2` in `packages/web-extension`
- Bumps `nanoid` from `^4.0.0` to `^5.0.9` in `packages/web-extension`

## Breaking changes in nanoid v5
- **Node.js >=18 required** — we use Node 20, not affected
- **Removed async API** (Web Crypto is sync-only now) — we only use sync `nanoid()`, not affected
- **Named export required** (`import { nanoid }`) — we already use named import, not affected
- **Removed CommonJS support** — web-extension is ESM (`"type": "module"`), not affected

## Breaking changes in react-router-dom 6.4 -> 6.30
- No breaking changes within the 6.x line. All APIs we use (`Routes`, `Route`, `useParams`, `useNavigate`, `createHashRouter`, `RouterProvider`) are stable

## Dependabot alerts resolved
- [Alert #168](https://github.com/getsentry/rrweb/security/dependabot/168) (medium) — react-router unvalidated redirect
- [Alert #167](https://github.com/getsentry/rrweb/security/dependabot/167) (high) — @remix-run/router XSS via open redirects
- [Alert #105](https://github.com/getsentry/rrweb/security/dependabot/105) (medium) — nanoid predictable generation
- [Alert #104](https://github.com/getsentry/rrweb/security/dependabot/104) (medium) — nanoid predictable generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)