### PR TITLE
fix(rrweb-worker): bump @rollup/plugin-terser to ^1.0.0

### DIFF
--- a/packages/rrweb-worker/package.json
+++ b/packages/rrweb-worker/package.json
@@ -35,7 +35,7 @@
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@types/css-font-loading-module": "0.0.7",
     "rollup": "^4.28.1",
-    "@rollup/plugin-terser": "^0.4.4",
+    "@rollup/plugin-terser": "^1.0.0",
     "rollup-plugin-typescript2": "^0.36.0",
     "vite": "^6.4.2",
     "vitest": "^2.1.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,12 +1415,12 @@
     is-module "^1.0.0"
     resolve "^1.22.1"
 
-"@rollup/plugin-terser@^0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz#15dffdb3f73f121aa4fbb37e7ca6be9aeea91962"
-  integrity sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==
+"@rollup/plugin-terser@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz#dabbc4414d127aa7d43fc5e7ea8699b9c3bc59e5"
+  integrity sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==
   dependencies:
-    serialize-javascript "^6.0.1"
+    serialize-javascript "^7.0.3"
     smob "^1.0.0"
     terser "^5.17.4"
 
@@ -7219,12 +7219,17 @@ semver@~7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
-serialize-javascript@^6.0.1, serialize-javascript@^6.0.2:
+serialize-javascript@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
   dependencies:
     randombytes "^2.1.0"
+
+serialize-javascript@^7.0.3:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
+  integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
 set-value@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary
- Bumps `@rollup/plugin-terser` from `^0.4.4` to `^1.0.0` in `packages/rrweb-worker`
- Pulls in `serialize-javascript@7.0.5` which resolves security alerts

## Breaking changes in @rollup/plugin-terser v1.0.0
- **Node.js >=20 required** — we use Node 20, not affected
- **`serialize-javascript` upgraded to v7** — internal dep, no API change. `terser()` plugin options unchanged, build verified passing

## Dependabot alerts resolved
- [Alert #239](https://github.com/getsentry/rrweb/security/dependabot/239) (medium) — serialize-javascript CPU exhaustion DoS
- [Alert #214](https://github.com/getsentry/rrweb/security/dependabot/214) (high) — serialize-javascript RCE via RegExp.flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)