### PR TITLE
fix: use CSS Declaration `replaceSync` to parse styles to avoid CSP violations

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -35,6 +35,8 @@ import {
   getShadowHost,
   closestElementOfNode,
 } from '../utils';
+import { StyleDeclarationParser } from './style-declaration-parser';
+
 import {
   getIFrameContentDocument,
   getIFrameContentWindow,
@@ -203,7 +205,7 @@ export default class MutationBuffer {
   private canvasManager: observerParam['canvasManager'];
   private processedNodeManager: observerParam['processedNodeManager'];
   private ignoreCSSAttributes: observerParam['ignoreCSSAttributes'];
-  private unattachedDoc: HTMLDocument;
+  private styleDeclarationParser!: StyleDeclarationParser;
 
   public init(options: MutationBufferParam) {
     (
@@ -240,6 +242,8 @@ export default class MutationBuffer {
       // just a type trick, the runtime result is correct
       this[key] = options[key] as never;
     });
+
+    this.styleDeclarationParser = new StyleDeclarationParser(this.doc);
   }
 
   public freeze() {
@@ -697,26 +701,15 @@ export default class MutationBuffer {
             this.maskAttributeFn,
           );
           if (attributeName === 'style') {
-            if (!this.unattachedDoc) {
-              try {
-                // avoid upsetting original document from a Content Security point of view
-                this.unattachedDoc =
-                  document.implementation.createHTMLDocument();
-              } catch (e) {
-                // fallback to more direct method
-                this.unattachedDoc = this.doc;
-              }
-            }
-            const old = this.unattachedDoc.createElement('span');
-            if (m.oldValue) {
-              old.setAttribute('style', m.oldValue);
-            }
+            const oldStyle = m.oldValue
+              ? this.styleDeclarationParser.parse(m.oldValue)
+              : null;
             for (const pname of Array.from(target.style)) {
               const newValue = target.style.getPropertyValue(pname);
               const newPriority = target.style.getPropertyPriority(pname);
               if (
-                newValue !== old.style.getPropertyValue(pname) ||
-                newPriority !== old.style.getPropertyPriority(pname)
+                newValue !== (oldStyle?.getPropertyValue(pname) || '') ||
+                newPriority !== (oldStyle?.getPropertyPriority(pname) || '')
               ) {
                 if (newPriority === '') {
                   item.styleDiff[pname] = newValue;
@@ -728,10 +721,12 @@ export default class MutationBuffer {
                 item._unchangedStyles[pname] = [newValue, newPriority];
               }
             }
-            for (const pname of Array.from(old.style)) {
-              if (target.style.getPropertyValue(pname) === '') {
-                // "if not set, returns the empty string"
-                item.styleDiff[pname] = false; // delete
+            if (oldStyle) {
+              for (const pname of Array.from(oldStyle)) {
+                if (target.style.getPropertyValue(pname) === '') {
+                  // "if not set, returns the empty string"
+                  item.styleDiff[pname] = false; // delete
+                }
               }
             }
           }

--- a/packages/rrweb/src/record/style-declaration-parser.ts
+++ b/packages/rrweb/src/record/style-declaration-parser.ts
@@ -10,6 +10,7 @@
  */
 export class StyleDeclarationParser {
   private unattachedDoc: Document | null = null;
+  private sheet: CSSStyleSheet | null = null;
 
   public constructor(private readonly doc: Document) {}
 
@@ -31,10 +32,12 @@ export class StyleDeclarationParser {
     }
 
     try {
-      const sheet = new CSSStyleSheet();
-      sheet.replaceSync(`x { ${styleText} }`);
+      if (!this.sheet) {
+        this.sheet = new CSSStyleSheet();
+      }
+      this.sheet.replaceSync(`x { ${styleText} }`);
 
-      const rule = sheet.cssRules[0];
+      const rule = this.sheet.cssRules[0];
       if (!rule || rule.type !== CSSRule.STYLE_RULE) {
         return null;
       }

--- a/packages/rrweb/src/record/style-declaration-parser.ts
+++ b/packages/rrweb/src/record/style-declaration-parser.ts
@@ -1,0 +1,66 @@
+/**
+ * This class is used to parse a style declaration into a CSSStyleDeclaration object.
+ * It uses an unattached doc unless `CSSStyleSheet.prototype.replaceSync` is available which can be used to bypass CSP violations.
+ * https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/replaceSync
+ * 
+ * This builds on https://github.com/getsentry/rrweb/pull/211#issuecomment-2284551183 which exhausted the other available options.
+ * 
+ * Note: This means some browsers (older than 23 March 2023) will use the unattached doc and may experience CSP violations,
+ * but newer browsers will use the replaceSync method and will not experience CSP violations.
+ */
+export class StyleDeclarationParser {
+  private unattachedDoc: Document | null = null;
+
+  public constructor(private readonly doc: Document) {}
+
+  public parse(styleText: string): CSSStyleDeclaration | null {
+    return (
+      this.parseWithConstructableStylesheet(styleText) ||
+      this.parseWithDetachedElement(styleText)
+    );
+  }
+
+  private parseWithConstructableStylesheet(
+    styleText: string,
+  ): CSSStyleDeclaration | null {
+    if (
+      typeof CSSStyleSheet === 'undefined' ||
+      typeof CSSStyleSheet.prototype.replaceSync !== 'function'
+    ) {
+      return null;
+    }
+
+    try {
+      const sheet = new CSSStyleSheet();
+      sheet.replaceSync(`x { ${styleText} }`);
+
+      const rule = sheet.cssRules[0];
+      if (!rule || rule.type !== CSSRule.STYLE_RULE) {
+        return null;
+      }
+
+      return (rule as CSSStyleRule).style;
+    } catch {
+      return null;
+    }
+  }
+
+  private parseWithDetachedElement(styleText: string): CSSStyleDeclaration {
+    const old = this.getUnattachedDoc().createElement('span');
+    old.setAttribute('style', styleText);
+    return old.style;
+  }
+
+  private getUnattachedDoc(): Document {
+    if (!this.unattachedDoc) {
+      try {
+        // avoid upsetting the observed document from a CSP point of view
+        this.unattachedDoc = document.implementation.createHTMLDocument();
+      } catch {
+        this.unattachedDoc = this.doc;
+      }
+    }
+
+    return this.unattachedDoc;
+  }
+}

--- a/packages/rrweb/src/record/style-declaration-parser.ts
+++ b/packages/rrweb/src/record/style-declaration-parser.ts
@@ -2,9 +2,9 @@
  * This class is used to parse a style declaration into a CSSStyleDeclaration object.
  * It uses an unattached doc unless `CSSStyleSheet.prototype.replaceSync` is available which can be used to bypass CSP violations.
  * https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/replaceSync
- * 
+ *
  * This builds on https://github.com/getsentry/rrweb/pull/211#issuecomment-2284551183 which exhausted the other available options.
- * 
+ *
  * Note: This means some browsers (older than 23 March 2023) will use the unattached doc and may experience CSP violations,
  * but newer browsers will use the replaceSync method and will not experience CSP violations.
  */

--- a/packages/rrweb/src/record/style-declaration-parser.ts
+++ b/packages/rrweb/src/record/style-declaration-parser.ts
@@ -10,7 +10,6 @@
  */
 export class StyleDeclarationParser {
   private unattachedDoc: Document | null = null;
-  private sheet: CSSStyleSheet | null = null;
 
   public constructor(private readonly doc: Document) {}
 
@@ -32,12 +31,10 @@ export class StyleDeclarationParser {
     }
 
     try {
-      if (!this.sheet) {
-        this.sheet = new CSSStyleSheet();
-      }
-      this.sheet.replaceSync(`x { ${styleText} }`);
+      const sheet = new CSSStyleSheet();
+      sheet.replaceSync(`x { ${styleText} }`);
 
-      const rule = this.sheet.cssRules[0];
+      const rule = sheet.cssRules[0];
       if (!rule || rule.type !== CSSRule.STYLE_RULE) {
         return null;
       }

--- a/packages/rrweb/test/record.test.ts
+++ b/packages/rrweb/test/record.test.ts
@@ -888,6 +888,43 @@ describe('record', function (this: ISuite) {
     });
   });
 
+  it('handles style mutations when unchanged values contain separators inside quoted strings', async () => {
+    await ctx.page.evaluate(() => {
+      const { record } = (window as unknown as IWindow).rrweb;
+
+      const div = document.createElement('div');
+      div.id = 'quoted-style-values';
+      div.setAttribute('style', '--message:"Hello: World;"; color:red;');
+      document.body.appendChild(div);
+
+      record({
+        emit: (window as unknown as IWindow).emit,
+      });
+    });
+
+    await waitForTimeout(50);
+    ctx.events = [];
+
+    await ctx.page.evaluate(() => {
+      const div = document.getElementById('quoted-style-values');
+      div?.setAttribute('style', '--message:"Hello: World;"; color:blue;');
+    });
+
+    await waitForTimeout(50);
+
+    const mutations = ctx.events.filter(
+      (e) =>
+        e.type === EventType.IncrementalSnapshot &&
+        e.data.source === IncrementalSource.Mutation,
+    );
+
+    expect(mutations).toHaveLength(1);
+    // @ts-expect-error data is unknown
+    expect(mutations[0].data.attributes[0].attributes.style).toEqual({
+      color: 'blue',
+    });
+  });
+
   describe('loading stylesheets', () => {
     let server: Server;
     let serverURL: string;

--- a/packages/rrweb/test/style-declaration-parser.test.ts
+++ b/packages/rrweb/test/style-declaration-parser.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { StyleDeclarationParser } from '../src/record/style-declaration-parser';
+
+const originalCSSStyleSheet = globalThis.CSSStyleSheet;
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'CSSStyleSheet', {
+    configurable: true,
+    writable: true,
+    value: originalCSSStyleSheet,
+  });
+  vi.restoreAllMocks();
+});
+
+describe('StyleDeclarationParser', () => {
+  it('falls back to detached element parsing when constructable stylesheets are unavailable', () => {
+    Object.defineProperty(globalThis, 'CSSStyleSheet', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const parser = new StyleDeclarationParser(document);
+
+    const style = parser.parse('--message:"Hello: World;"; color:blue;');
+
+    expect(style?.getPropertyValue('--message')).toBe('"Hello: World;"');
+    expect(style?.getPropertyValue('color')).toBe('blue');
+  });
+
+  it('uses constructable stylesheet parsing when replaceSync is available', () => {
+    const fakeStyle = document.createElement('span').style;
+    fakeStyle.setProperty('--message', '"Hello: World;"');
+    fakeStyle.setProperty('color', 'blue');
+
+    class FakeCSSStyleSheet {
+      public cssRules: CSSRule[] = [];
+
+      public replaceSync(_text: string): void {
+        this.cssRules = [
+          {
+            type: CSSRule.STYLE_RULE,
+            style: fakeStyle,
+          } as CSSRule,
+        ];
+      }
+    }
+
+    Object.defineProperty(globalThis, 'CSSStyleSheet', {
+      configurable: true,
+      writable: true,
+      value: FakeCSSStyleSheet,
+    });
+
+    const parser = new StyleDeclarationParser(document);
+    const fallbackSpy = vi.spyOn(
+      parser as unknown as {
+        parseWithDetachedElement: (styleText: string) => CSSStyleDeclaration;
+      },
+      'parseWithDetachedElement',
+    );
+
+    const style = parser.parse('--message:"Hello: World;"; color:blue;');
+
+    expect(style?.getPropertyValue('--message')).toBe('"Hello: World;"');
+    expect(style?.getPropertyValue('color')).toBe('blue');
+    expect(fallbackSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Partially addresses https://github.com/getsentry/sentry-javascript/issues/10481 at least from rrweb side.

The problem is that rrweb computes `style`-attribute diffs by reparsing the previous inline style string through a detached DOM element. The old code did:

```ts
const old = document.createElement('span');
old.setAttribute('style', m.oldValue);
```

That works as a parser, but in browsers with strict CSP it can trigger a `style-src-attr` violation, because it gets treated as applying an inline `style` attribute even though the element is never attached to the page. This means rrweb can hit CSP errors while trying to diff inline style mutations.

The idea of the fix is to keep using the browser’s CSS parser, but avoid parsing through a DOM element. In browsers that support constructable stylesheets, we wrap the inline declaration list in a harmless CSS rule and parse it with `CSSStyleSheet.replaceSync()`:

```ts
const sheet = new CSSStyleSheet();
sheet.replaceSync(`x { ${styleText} }`);
const oldStyle = (sheet.cssRules[0] as CSSStyleRule).style;
```

`replaceSync()` expects full stylesheet text, so `x { ... }` is just the smallest valid rule wrapper around the inline declaration block. The selector itself does not matter because we never use it for matching; we only read back `cssRules[0].style`, which gives us the parsed `CSSStyleDeclaration`.

This works because rrweb only needs to compare explicit inline declarations, not computed or cascaded styles. Parsing `style="color:red; left:10px"` through a detached element and parsing `x { color:red; left:10px }` through the stylesheet parser both yield the same declaration list, including priorities like `!important`.

For older supported browsers that do not implement constructable stylesheets, we keep the existing detached-element fallback so behavior remains unchanged.

---

I verified this in a test app that has CSP headers and triggered this error on current builds, it doesn't after this change.