### PR TITLE
ci: declare least-privilege permissions on workflow jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -14,6 +14,8 @@ jobs:
   job_test:
     name: Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
@@ -53,6 +55,8 @@ jobs:
     needs: job_test
     name: Upload Artifacts
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Build artifacts are only needed for releasing workflow.
     if: startsWith(github.ref, 'refs/heads/release/')
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: 'Release a new version'
+    permissions:
+      contents: read
     steps:
       - name: Get auth token
         id: token


### PR DESCRIPTION
Adds explicit \`permissions: contents: read\` to jobs in \`ci-cd.yml\` and \`release.yml\`. Without it, the default \`GITHUB_TOKEN\` inherits whatever the repo/org default is.

\`release.yml\`'s actual write operations all use a separate GitHub App token (\`steps.token.outputs.token\`), so the default \`GITHUB_TOKEN\` only needs to read.

Matches the pattern already used in \`eslint-check.yml\` and \`style-check.yml\`.