### PR TITLE
fix(rrweb-snapshot): rewrite vulnerable regexes flagged by CodeQL

### DIFF
--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -439,10 +439,9 @@ export function parse(css: string, options: ParserOptions = {}) {
       return;
     }
 
-    /* @fix Remove all comments from selectors
-     * http://ostermiller.org/findcomment.html */
+    /* @fix Remove all comments from selectors */
     const splitSelectors = trim(m[0])
-      .replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*\/+/g, '')
+      .replace(/\/\*[\s\S]*?\*\/+/g, '')
       .replace(/"(?:\\"|[^"])*"|'(?:\\'|[^'])*'/g, (m) => {
         return m.replace(/,/g, '\u200C');
       })

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1345,7 +1345,7 @@ export function serializeNodeWithId(
     (!preserveWhiteSpace &&
       _serializedNode.type === NodeType.Text &&
       !_serializedNode.isStyle &&
-      !_serializedNode.textContent.replace(/^\s+|\s+$/gm, '').length)
+      !_serializedNode.textContent.trim().length)
   ) {
     id = IGNORED_NODE;
   } else {

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -114,7 +114,9 @@ describe('css parser', () => {
   it('should not catastrophically backtrack on unterminated selector comments', () => {
     const evil = '/*' + '\n*'.repeat(40);
     const start = Date.now();
-    expect(() => parse(`${evil} { color: red; }`, { silent: true })).not.toThrow();
+    expect(() =>
+      parse(`${evil} { color: red; }`, { silent: true }),
+    ).not.toThrow();
     expect(Date.now() - start).toBeLessThan(500);
   });
 

--- a/packages/rrweb-snapshot/test/css.test.ts
+++ b/packages/rrweb-snapshot/test/css.test.ts
@@ -97,6 +97,27 @@ describe('css parser', () => {
     expect(decl.parent).toEqual(rule);
   });
 
+  it('should strip comments from selectors', () => {
+    const cases: Array<[string, string[]]> = [
+      ['.foo /* comment */, .bar { color: red; }', ['.foo', '.bar']],
+      ['a /* x */ b, c /* y */ d { color: red; }', ['a  b', 'c  d']],
+      ['.x /* trailing */ { color: red; }', ['.x']],
+    ];
+    for (const [css, expected] of cases) {
+      const rules = parse(css).stylesheet!.rules.filter(
+        (r): r is Rule => r.type === 'rule',
+      );
+      expect(rules[0].selectors?.map((s) => s.trim())).toEqual(expected);
+    }
+  });
+
+  it('should not catastrophically backtrack on unterminated selector comments', () => {
+    const evil = '/*' + '\n*'.repeat(40);
+    const start = Date.now();
+    expect(() => parse(`${evil} { color: red; }`, { silent: true })).not.toThrow();
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
   // TODO(sentry): our parser can't handle this atm
   it.skip('parses { and } in attribute selectors correctly', () => {
     const result = parse('foo[someAttr~="{someId}"] { color: red; }');


### PR DESCRIPTION
Rewrites two regexes flagged by CodeQL: the CSS-comment-stripping regex in css.ts (CodeQL alerts 5 and 6) had nested quantifiers causing exponential backtracking on unterminated comments, and the whitespace-trim regex in snapshot.ts (CodeQL alert 4) was polynomial.

Both replacements are observably identical for well-formed input; the new comment regex additionally strips two malformed-but-valid comment shapes (`/***/`, `/**foo**/`) that the old one left unchanged.