### PR TITLE
feat(rrweb): expose canvas manager subpath

### DIFF
--- a/packages/rrdom-nodejs/vite.config.js
+++ b/packages/rrdom-nodejs/vite.config.js
@@ -1,4 +1,6 @@
 import path from 'path';
 import config from '../../vite.config.default';
 
-export default config(path.resolve(__dirname, 'src/index.ts'), 'rrdomNodejs');
+export default config(path.resolve(__dirname, 'src/index.ts'), 'rrdomNodejs', {
+  umdPlatform: 'node',
+});

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -36,11 +36,19 @@
   "typings": "dist/rrweb.d.ts",
   "typesVersions": {
     "<3.9": {
+      "canvas-manager": [
+        "dist/ts3.8/canvas-manager.d.ts"
+      ],
       "dist/rrweb.d.ts": [
         "dist/ts3.8/rrweb.d.ts"
       ],
       "dist/canvas-manager.d.ts": [
         "dist/ts3.8/canvas-manager.d.ts"
+      ]
+    },
+    "*": {
+      "canvas-manager": [
+        "dist/canvas-manager.d.ts"
       ]
     }
   },

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -38,6 +38,9 @@
     "<3.9": {
       "dist/rrweb.d.ts": [
         "dist/ts3.8/rrweb.d.ts"
+      ],
+      "dist/canvas-manager.d.ts": [
+        "dist/ts3.8/canvas-manager.d.ts"
       ]
     }
   },
@@ -50,6 +53,16 @@
       "require": {
         "types": "./dist/rrweb.d.cts",
         "default": "./dist/rrweb.cjs"
+      }
+    },
+    "./canvas-manager": {
+      "import": {
+        "types": "./dist/canvas-manager.d.ts",
+        "default": "./dist/canvas-manager.js"
+      },
+      "require": {
+        "types": "./dist/canvas-manager.d.cts",
+        "default": "./dist/canvas-manager.cjs"
       }
     },
     "./dist/style.css": "./dist/style.css"

--- a/packages/rrweb/src/entries/canvas-manager.ts
+++ b/packages/rrweb/src/entries/canvas-manager.ts
@@ -1,0 +1,4 @@
+export {
+  CanvasManager,
+  type CanvasManagerConstructorOptions,
+} from '../record/observers/canvas/canvas-manager';

--- a/packages/rrweb/vite.config.js
+++ b/packages/rrweb/vite.config.js
@@ -1,4 +1,9 @@
 import config from '../../vite.config.default';
 
-// export default config('src/index.ts', 'rrweb', { outputDir: 'dist/main' });
-export default config('src/index.ts', 'rrweb');
+export default config(
+  {
+    rrweb: 'src/index.ts',
+    'canvas-manager': 'src/entries/canvas-manager.ts',
+  },
+  'rrweb',
+);

--- a/packages/rrweb/vite.config.js
+++ b/packages/rrweb/vite.config.js
@@ -6,4 +6,9 @@ export default config(
     'canvas-manager': 'src/entries/canvas-manager.ts',
   },
   'rrweb',
+  {
+    umdNames: {
+      'canvas-manager': 'rrwebCanvasManager',
+    },
+  },
 );

--- a/vite.config.default.ts
+++ b/vite.config.default.ts
@@ -3,7 +3,7 @@ import dts from 'vite-plugin-dts';
 import { copyFileSync } from 'node:fs';
 import { defineConfig, LibraryOptions, LibraryFormats, Plugin } from 'vite';
 import glob from 'fast-glob';
-import { build, Format } from 'esbuild';
+import { build, Format, Platform } from 'esbuild';
 import { resolve } from 'path';
 import { umdWrapper } from 'esbuild-plugin-umd-wrapper';
 
@@ -12,9 +12,13 @@ const emptyOutDir = process.env.CLEAR_DIST_DIR !== 'false';
 function minifyAndUMDPlugin({
   name,
   outDir,
+  platform,
+  umdNames,
 }: {
   name: LibraryOptions['name'];
   outDir: string;
+  platform: Platform;
+  umdNames: Record<string, LibraryOptions['name']>;
 }): Plugin {
   return {
     name: 'minify-plugin',
@@ -33,6 +37,7 @@ function minifyAndUMDPlugin({
             /(\.cjs|\.css)(\.map)?$/,
             '',
           );
+          const libraryName = umdNames[baseFileName] || name;
           const outputFilePath = resolve(outputOptions.dir!, baseFileName);
           // console.log(outputFilePath, 'minifying', file.fileName);
           if (isCSS) {
@@ -45,20 +50,22 @@ function minifyAndUMDPlugin({
             });
           } else {
             await buildFile({
-              name,
+              name: libraryName,
               input: inputFilePath,
               output: `${outputFilePath}.umd.cjs`,
               minify: false,
               isCss: false,
               outDir,
+              platform,
             });
             await buildFile({
-              name,
+              name: libraryName,
               input: inputFilePath,
               output: `${outputFilePath}.umd.min.cjs`,
               minify: true,
               isCss: false,
               outDir,
+              platform,
             });
           }
         }
@@ -74,6 +81,7 @@ async function buildFile({
   minify,
   isCss,
   outDir,
+  platform,
 }: {
   name?: LibraryOptions['name'];
   input: string;
@@ -81,13 +89,16 @@ async function buildFile({
   outDir: string;
   minify: boolean;
   isCss: boolean;
+  platform: Platform;
 }) {
   await build({
     entryPoints: [input],
     outfile: output,
+    bundle: !isCss,
     minify,
     sourcemap: true,
     format: isCss ? undefined : ('umd' as Format),
+    platform: isCss ? undefined : platform,
     target: isCss ? undefined : 'es2020',
     treeShaking: !isCss,
     plugins: [
@@ -104,9 +115,21 @@ async function buildFile({
 export default function (
   entry: LibraryOptions['entry'],
   name: LibraryOptions['name'],
-  options?: { outputDir?: string; fileName?: string; plugins?: Plugin[] },
+  options?: {
+    outputDir?: string;
+    fileName?: string;
+    plugins?: Plugin[];
+    umdPlatform?: Platform;
+    umdNames?: Record<string, LibraryOptions['name']>;
+  },
 ) {
-  const { fileName, outputDir: outDir = 'dist', plugins = [] } = options || {};
+  const {
+    fileName,
+    outputDir: outDir = 'dist',
+    plugins = [],
+    umdPlatform = 'browser',
+    umdNames = {},
+  } = options || {};
 
   let formats: LibraryFormats[] = ['es', 'cjs'];
 
@@ -159,7 +182,12 @@ export default function (
           });
         },
       }),
-      minifyAndUMDPlugin({ name, outDir }),
+      minifyAndUMDPlugin({
+        name,
+        outDir,
+        platform: umdPlatform,
+        umdNames,
+      }),
       ...plugins,
     ],
   }));


### PR DESCRIPTION
This PR exposes the `CanvasManager` as a subpath export, the reason for this is that the `rrweb` package has some side effects along the export path that pins the whole graph.

That prevents Rolldown's DCE from dropping it properly in sentry SDKs, blocking the adoption of rolldown. Rollup seemed to handle this properly.

I will release this once merged.