### PR TITLE
chore: publish renamed rrweb packages publicly

### DIFF
--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -41,6 +41,9 @@
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@sentry/rrweb-types": "2.43.0",
     "@typescript-eslint/eslint-plugin": "^5.23.0",

--- a/packages/rrweb-player/package.json
+++ b/packages/rrweb-player/package.json
@@ -64,5 +64,8 @@
   "bugs": {
     "url": "https://github.com/rrweb-io/rrweb/issues"
   },
-  "homepage": "https://github.com/rrweb-io/rrweb#readme"
+  "homepage": "https://github.com/rrweb-io/rrweb#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -57,6 +57,9 @@
     "url": "https://github.com/rrweb-io/rrweb/issues"
   },
   "homepage": "https://github.com/rrweb-io/rrweb/tree/master/packages/rrweb-snapshot#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@types/jsdom": "^20.0.0",
     "@types/node": "^18.15.11",

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -86,6 +86,9 @@
     "url": "https://github.com/rrweb-io/rrweb/issues"
   },
   "homepage": "https://github.com/rrweb-io/rrweb#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "@sentry/rrweb-worker": "2.43.0",
     "@types/dom-mediacapture-transform": "0.1.4",


### PR DESCRIPTION
Hit a classic issue during publish, new packages are private by default 🤦‍♂️ 