### PR TITLE
fix: Don't clear live WebGL buffer during canvas snapshots

### DIFF
--- a/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
+++ b/packages/rrweb/src/record/observers/canvas/canvas-manager.ts
@@ -1,4 +1,4 @@
-import type { ICanvas, Mirror, DataURLOptions } from '@sentry/rrweb-snapshot';
+import type { Mirror, DataURLOptions } from '@sentry/rrweb-snapshot';
 import type {
   blockClass,
   canvasManagerMutationCallback,
@@ -238,11 +238,11 @@ export class CanvasManager implements CanvasManagerInterface {
     options?: SnapshotOptions,
   ): void {
     if (options?.skipRequestAnimationFrame) {
-      this.takeSnapshot(performance.now(), true, canvasElement);
+      this.takeSnapshot(performance.now(), canvasElement);
       return;
     }
     onRequestAnimationFrame((timestamp) =>
-      this.takeSnapshot(timestamp, true, canvasElement),
+      this.takeSnapshot(timestamp, canvasElement),
     );
   }
 
@@ -317,7 +317,7 @@ export class CanvasManager implements CanvasManagerInterface {
     }
 
     const rafCallback = (timestamp: DOMHighResTimeStamp) => {
-      this.takeSnapshot(timestamp, false);
+      this.takeSnapshot(timestamp);
       rafId = onRequestAnimationFrame(rafCallback);
     };
 
@@ -424,7 +424,6 @@ export class CanvasManager implements CanvasManagerInterface {
    */
   private takeSnapshot(
     timestamp: DOMHighResTimeStamp,
-    isManualSnapshot: boolean,
     canvasElement?: HTMLCanvasElement,
   ) {
     const {
@@ -466,27 +465,14 @@ export class CanvasManager implements CanvasManagerInterface {
 
       this.snapshotInProgressMap.set(id, true);
 
-      // Handle WebGL context preservation
-      if (
-        !isManualSnapshot &&
-        ['webgl', 'webgl2'].includes((canvas as ICanvas).__context)
-      ) {
-        const context = canvas.getContext((canvas as ICanvas).__context) as
-          | WebGLRenderingContext
-          | WebGL2RenderingContext
-          | null;
-
-        if (context?.getContextAttributes()?.preserveDrawingBuffer === false) {
-          // Hack to load canvas back into memory so `createImageBitmap` can grab it's contents.
-          // Context: https://twitter.com/Juice10/status/1499775271758704643
-          // Preferably we set `preserveDrawingBuffer` to true, but that's not always possible,
-          // especially when canvas is loaded before rrweb.
-          // This hack can wipe the background color of the canvas in the (unlikely) event that
-          // the canvas background was changed but clear was not called directly afterwards.
-          // Example of this hack having negative side effect: https://visgl.github.io/react-map-gl/examples/layers
-          context.clear(context.COLOR_BUFFER_BIT);
-        }
-      }
+      // Note: we intentionally do NOT clear the WebGL color buffer here to force
+      // the drawing buffer back into memory. Doing so wipes the application's own
+      // live canvas on every snapshot, which for on-demand-rendered canvases
+      // (maps, 3D viewers, charts) causes visible blinking. Buffer preservation
+      // is handled by forcing `preserveDrawingBuffer: true` in the getContext
+      // patch; when that is not possible, a blank snapshot is preferable to
+      // corrupting the host application's rendering.
+      // See: https://github.com/getsentry/sentry-javascript/issues/20178
 
       createImageBitmap(canvas)
         .then((bitmap) => {


### PR DESCRIPTION
## What

Stop the canvas snapshot loop from clearing the application's live WebGL color  <br>buffer on every snapshot.

* Remove the `gl.clear(COLOR_BUFFER_BIT)` call in `CanvasManager.takeSnapshot`.
* Drop the now-unused `isManualSnapshot` parameter it gated.

## Why

The clear was a hack to pull an on-demand WebGL canvas back into memory so  <br>`createImageBitmap` could read it. It only ran when `preserveDrawingBuffer` was  <br>`false`, which is exactly the case where the read comes back blank anyway, so it  <br>never produced a usable snapshot. Meanwhile it wiped the host app's live canvas  <br>every tick, making on-demand-rendered canvases visibly blink. Buffer preservation  <br>is already handled by forcing `preserveDrawingBuffer: true` in the getContext patch  <br>when possible.

## History

The clear was always the weaker of two mechanisms, and the stronger one already  <br>supersedes it for the common case:

* [rrweb-io/rrweb#859](<https://github.com/rrweb-io/rrweb/issues/859>) (Record canvas snapshots N times per second) introduced the  <br>FPS snapshot feature and this clear hack, as the only way to coax content out of  <br>a `preserveDrawingBuffer: false` canvas.
* [rrweb-io/rrweb#1273](<https://github.com/rrweb-io/rrweb/issues/1273>) (Canvas recording: Preserve drawing buffer) added the real  <br>fix, forcing `preserveDrawingBuffer: true` on canvas creation via the getContext  <br>patch, and demoted the clear to a fallback for the "canvas created before rrweb"  <br>case where that patch cannot apply.

This PR removes that leftover fallback. The [#1273](<https://github.com/getsentry/rrweb/issues/1273>) mechanism is untouched, so the  <br>common case still captures fine; the fallback case now records a blank snapshot  <br>instead of corrupting the host app's live canvas.

Closes: getsentry/rrweb#308