### PR TITLE
chore(dev-deps): Pin `shell-quote` to `^1.10.0` to patch op injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "**/@types/dom-webcodecs": "0.1.5",
     "**/@types/estree": "^1.0.0",
     "**/vite": "^6.4.2",
-    "**/tmp": "0.2.5"
+    "**/tmp": "0.2.5",
+    "**/shell-quote": "^1.10.0"
   },
   "browserslist": [
     "defaults",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6750,15 +6750,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.3:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
-  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
-
-shell-quote@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
+shell-quote@1.7.3, shell-quote@1.8.3, shell-quote@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.10.0.tgz#482033e192e4f5c07151521ffa03400ec71b1b0f"
+  integrity sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==
 
 shelljs@^0.8.3:
   version "0.8.5"


### PR DESCRIPTION
Patches `shell-quote` GHSA-w7jw-789q-3m8p / CVE-2026-9277 (`quote()` did not escape line terminators in object-token `.op` values).

Two dev-only copies were in the lockfile: 1.8.3 via `concurrently`, and 1.7.3 via the private `web-extension` package -> `web-ext-run` -> `fx-runner@1.4.0`. A lockfile refresh alone does not fix the second one — `fx-runner@1.4.0` pins 1.7.3 exactly and the latest `web-ext-run` still pins that fx-runner — so this adds a resolution. Both dedupe to a single 1.10.0.

Nothing shipped to users was affected: no published `@sentry/*` package has `shell-quote` in its dependency tree and no source file imports it.

Resolves Dependabot alert 279 and https://github.com/getsentry/rrweb/security/dependabot/294