### PR TITLE
fix(masking): Propagate masking and blocking from a shadow host into its shadow root

### DIFF
--- a/.changeset/shadow-host-masking.md
+++ b/.changeset/shadow-host-masking.md
@@ -1,0 +1,8 @@
+---
+'rrweb-snapshot': patch
+'rrweb': patch
+---
+
+Fix masking and blocking not propagating from a shadow host into its shadow root
+
+`distanceToMatch` stopped its ancestor walk at the shadow boundary, so a `maskTextSelector`/`maskTextClass` or `blockSelector`/`blockClass` match on an open shadow host was never seen by nodes inside that host's shadow root. Text, attribute mutations, and input values inside the shadow tree were recorded unmasked. The walk now steps from a shadow root onto its host, which also makes unmask/unblock selectors inside a shadow root resolve against a matched host.

--- a/.changeset/shadow-host-masking.md
+++ b/.changeset/shadow-host-masking.md
@@ -1,6 +1,6 @@
 ---
-'rrweb-snapshot': patch
-'rrweb': patch
+"rrweb-snapshot": patch
+"rrweb": patch
 ---
 
 Fix masking and blocking not propagating from a shadow host into its shadow root

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -402,6 +402,12 @@ export function distanceToMatch(
   distance = 0,
 ): number {
   if (!node) return -1;
+  // Masking and blocking configured on a shadow host has to apply to that host's
+  // shadow content, so step from a shadow root onto its host rather than stopping
+  // at the boundary.
+  if (isShadowRoot(node)) {
+    return distanceToMatch(node.host, matchPredicate, limit, distance + 1);
+  }
   if (node.nodeType !== node.ELEMENT_NODE) return -1;
   if (distance > limit) return -1;
   if (matchPredicate(node)) return distance;

--- a/packages/rrweb-snapshot/test/snapshot.test.ts
+++ b/packages/rrweb-snapshot/test/snapshot.test.ts
@@ -551,6 +551,141 @@ describe('needMaskingText', () => {
     ).toEqual(false);
   });
 
+  describe('shadow DOM', () => {
+    const renderShadowHost = (
+      hostHtml: string,
+      shadowHtml: string,
+    ): ShadowRoot => {
+      const host = render(hostHtml);
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      shadowRoot.innerHTML = shadowHtml;
+      return shadowRoot;
+    };
+
+    it('should mask if the masking selector is matched on the shadow host', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo'></div>`,
+        `<span>Lorem ipsum</span>`,
+      );
+      expect(
+        needMaskingText(
+          shadowRoot.querySelector('span')!,
+          'maskmask',
+          '.foo',
+          'unmaskmask',
+          null,
+          false,
+        ),
+      ).toEqual(true);
+    });
+
+    it('should mask if the masking class is matched on the shadow host', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo maskmask'></div>`,
+        `<p><span>Lorem ipsum</span></p>`,
+      );
+      expect(
+        needMaskingText(
+          shadowRoot.querySelector('span')!,
+          'maskmask',
+          null,
+          'unmaskmask',
+          null,
+          false,
+        ),
+      ).toEqual(true);
+    });
+
+    it('should mask if the masking selector is matched on an ancestor of the shadow host', () => {
+      const el = render(`<div class='foo'><div class='host'></div></div>`);
+      const shadowRoot = el
+        .querySelector('.host')!
+        .attachShadow({ mode: 'open' });
+      shadowRoot.innerHTML = `<span>Lorem ipsum</span>`;
+      expect(
+        needMaskingText(
+          shadowRoot.querySelector('span')!,
+          'maskmask',
+          '.foo',
+          'unmaskmask',
+          null,
+          false,
+        ),
+      ).toEqual(true);
+    });
+
+    it('should mask if the masking selector is matched on an outer shadow host', () => {
+      const outerShadowRoot = renderShadowHost(
+        `<div class='foo'></div>`,
+        `<div class='inner-host'></div>`,
+      );
+      const innerShadowRoot = outerShadowRoot
+        .querySelector('.inner-host')!
+        .attachShadow({ mode: 'open' });
+      innerShadowRoot.innerHTML = `<span>Lorem ipsum</span>`;
+      expect(
+        needMaskingText(
+          innerShadowRoot.querySelector('span')!,
+          'maskmask',
+          '.foo',
+          'unmaskmask',
+          null,
+          false,
+        ),
+      ).toEqual(true);
+    });
+
+    it('should not mask if the unmasking selector is matched inside the shadow root', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo'></div>`,
+        `<div class='bar'><span>Lorem ipsum</span></div>`,
+      );
+      expect(
+        needMaskingText(
+          shadowRoot.querySelector('span')!,
+          'maskmask',
+          '.foo',
+          'unmaskmask',
+          '.bar',
+          false,
+        ),
+      ).toEqual(false);
+    });
+
+    it('should not mask if the unmasking selector is matched on the shadow host', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo'></div>`,
+        `<span>Lorem ipsum</span>`,
+      );
+      expect(
+        needMaskingText(
+          shadowRoot.querySelector('span')!,
+          'maskmask',
+          null,
+          'unmaskmask',
+          '.foo',
+          true,
+        ),
+      ).toEqual(false);
+    });
+
+    it('should not cross a closed shadow root', () => {
+      const host = render(`<div class='foo'></div>`);
+      const shadowRoot = host.attachShadow({ mode: 'closed' });
+      shadowRoot.innerHTML = `<span>Lorem ipsum</span>`;
+      expect(
+        needMaskingText(
+          shadowRoot.querySelector('span')!,
+          'maskmask',
+          '.foo',
+          'unmaskmask',
+          null,
+          false,
+        ),
+      ).toEqual(false);
+    });
+  });
+
   describe('enforced masking', () => {
     it.each([
       'current-password',

--- a/packages/rrweb/test/util.test.ts
+++ b/packages/rrweb/test/util.test.ts
@@ -3,6 +3,7 @@
  */
 import {
   getRootShadowHost,
+  isBlocked,
   StyleSheetMirror,
   inDom,
   shadowHostInDom,
@@ -141,6 +142,98 @@ describe('Utilities for other modules', () => {
       expect(getRootShadowHost(a.childNodes[0])).toBe(a.childNodes[0]);
       expect(shadowHostInDom(a.childNodes[0])).toBeTruthy();
       expect(inDom(a.childNodes[0])).toBeTruthy();
+    });
+  });
+  describe('isBlocked', () => {
+    const renderShadowHost = (
+      hostHtml: string,
+      shadowHtml: string,
+    ): ShadowRoot => {
+      document.body.innerHTML = hostHtml;
+      const host = document.body.querySelector('div')!;
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      shadowRoot.innerHTML = shadowHtml;
+      return shadowRoot;
+    };
+
+    it('should block a node whose shadow host matches the block selector', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo'></div>`,
+        `<p><span>Lorem ipsum</span></p>`,
+      );
+      expect(
+        isBlocked(
+          shadowRoot.querySelector('span')!,
+          'blockblock',
+          '.foo',
+          null,
+          true,
+        ),
+      ).toEqual(true);
+    });
+
+    it('should block a node whose shadow host matches the block class', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo blockblock'></div>`,
+        `<span>Lorem ipsum</span>`,
+      );
+      expect(
+        isBlocked(
+          shadowRoot.querySelector('span')!,
+          'blockblock',
+          null,
+          null,
+          true,
+        ),
+      ).toEqual(true);
+    });
+
+    it('should not block a node whose shadow host does not match', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo'></div>`,
+        `<span>Lorem ipsum</span>`,
+      );
+      expect(
+        isBlocked(
+          shadowRoot.querySelector('span')!,
+          'blockblock',
+          '.bar',
+          null,
+          true,
+        ),
+      ).toEqual(false);
+    });
+
+    it('should not block a node unblocked inside the shadow root of a blocked host', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo'></div>`,
+        `<div class='bar'><span>Lorem ipsum</span></div>`,
+      );
+      expect(
+        isBlocked(
+          shadowRoot.querySelector('span')!,
+          'blockblock',
+          '.foo',
+          '.bar',
+          true,
+        ),
+      ).toEqual(false);
+    });
+
+    it('should not check ancestors when checkAncestors is false', () => {
+      const shadowRoot = renderShadowHost(
+        `<div class='foo'></div>`,
+        `<span>Lorem ipsum</span>`,
+      );
+      expect(
+        isBlocked(
+          shadowRoot.querySelector('span')!,
+          'blockblock',
+          '.foo',
+          null,
+          false,
+        ),
+      ).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
Makes `data-sentry-mask` / `data-sentry-block` on an open shadow host actually apply to the nodes inside that host's shadow root.

`distanceToMatch` walked up via `parentNode` and bailed on the first non-element. A `ShadowRoot` is a `DOCUMENT_FRAGMENT_NODE`, so the walk died at the shadow boundary and never reached `shadowRoot.host`. 

The upstream rrweb has the same bug via `el.closest()`, which doesn't cross shadow boundaries either, and there's no upstream issue or fix for it 🤔 

The downside for this is I see the performance exploding for apps that make heavy use of web components, especially ones that don't mask anything in there. 

Also this introduces a large behavior change, and maybe two trade offs:

**A:** mask and unmask both cross into the shadow root. Consistent, but it can silently un-mask content that's masked today. Technically we fixed a bug tho. 

**B:** only mask and block cross. Unmask stays outside. Changes nothing for the default config, and fixes the original report. The cost is that `data-sentry-unmask` on a host silently does nothing, so you can't unmask a third-party component from outside it.

The PR currently implements A which I think while more aggressive, is the more consistent and has less "but"s.