### PR TITLE
fix(rrweb): Guard cross-origin `Element` read in ShadowDomManager.obs…

### DIFF
--- a/.changeset/cross-origin-attach-shadow-guard.md
+++ b/.changeset/cross-origin-attach-shadow-guard.md
@@ -1,0 +1,5 @@
+---
+"rrweb": patch
+---
+
+Fix: guard cross-origin `Element` read in `ShadowDomManager.observeAttachShadow` so it no longer throws SecurityError/TypeError into the host page

--- a/.changeset/cross-origin-attach-shadow-guard.md
+++ b/.changeset/cross-origin-attach-shadow-guard.md
@@ -1,5 +1,0 @@
----
-"rrweb": patch
----
-
-Fix: guard cross-origin `Element` read in `ShadowDomManager.observeAttachShadow` so it no longer throws SecurityError/TypeError into the host page

--- a/packages/rrweb/src/record/shadow-dom-manager.ts
+++ b/packages/rrweb/src/record/shadow-dom-manager.ts
@@ -129,14 +129,22 @@ export class ShadowDomManager implements ShadowDomManagerInterface {
     const iframeDoc = getIFrameContentDocument(iframeElement);
     const iframeWindow = getIFrameContentWindow(iframeElement);
     if (!iframeDoc || !iframeWindow) return;
-    this.patchAttachShadow(
-      (
+
+    // For a cross-origin iframe, `contentWindow` is a truthy-restricted proxy.
+    // Reading `Element` off it throws SecurityError (or yields undefined).
+    let iframeElementConstructor: { prototype: Element } | undefined;
+    try {
+      iframeElementConstructor = (
         iframeWindow as Window & {
-          Element: { prototype: Element };
+          Element?: { prototype: Element };
         }
-      ).Element,
-      iframeDoc,
-    );
+      ).Element;
+    } catch (e) {
+      return;
+    }
+    if (!iframeElementConstructor) return;
+
+    this.patchAttachShadow(iframeElementConstructor, iframeDoc);
   }
 
   /**

--- a/packages/rrweb/test/record/shadow-dom-manager.test.ts
+++ b/packages/rrweb/test/record/shadow-dom-manager.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { vi } from 'vitest';
+import type { Mirror } from '@sentry/rrweb-snapshot';
+import { ShadowDomManager } from '../../src/record/shadow-dom-manager';
+
+type BypassOptions = ConstructorParameters<
+  typeof ShadowDomManager
+>[0]['bypassOptions'];
+
+function createManager(): ShadowDomManager {
+  return new ShadowDomManager({
+    mutationCb: vi.fn(),
+    scrollCb: vi.fn(),
+    bypassOptions: {
+      canvasManager: {
+        addShadowRoot: vi.fn(),
+        resetShadowRoots: vi.fn(),
+      },
+    } as unknown as BypassOptions,
+    mirror: { getId: vi.fn() } as unknown as Mirror,
+  });
+}
+
+describe('ShadowDomManager', () => {
+  // Regression tests for https://github.com/getsentry/rrweb/issues/321:
+  // a cross-origin iframe's `contentWindow` is a truthy-restricted proxy, so
+  // the unguarded `iframeWindow.Element` read threw into the host page.
+  describe('observeAttachShadow', () => {
+    it('does not throw when reading a property of a cross-origin window throws', () => {
+      const restrictedWindow = new Proxy(
+        {},
+        {
+          get() {
+            throw new DOMException(
+              "Failed to read a named property 'Element' from 'Window': Blocked a frame from accessing a cross-origin frame.",
+              'SecurityError',
+            );
+          },
+        },
+      );
+      const iframe = {
+        contentDocument: document.implementation.createHTMLDocument(),
+        contentWindow: restrictedWindow,
+      } as unknown as HTMLIFrameElement;
+      const manager = createManager();
+
+      expect(() => manager.observeAttachShadow(iframe)).not.toThrow();
+    });
+
+    it('does not throw when the iframe window has no Element constructor', () => {
+      const iframe = {
+        contentDocument: document.implementation.createHTMLDocument(),
+        contentWindow: {},
+      } as unknown as HTMLIFrameElement;
+      const manager = createManager();
+
+      expect(() => manager.observeAttachShadow(iframe)).not.toThrow();
+    });
+
+    it('patches attachShadow of an accessible iframe window', () => {
+      class FakeElement {
+        attachShadow() {
+          return {} as ShadowRoot;
+        }
+      }
+      const original = FakeElement.prototype.attachShadow;
+      const iframe = {
+        contentDocument: document.implementation.createHTMLDocument(),
+        contentWindow: { Element: FakeElement },
+      } as unknown as HTMLIFrameElement;
+      const manager = createManager();
+
+      manager.observeAttachShadow(iframe);
+
+      const patched = FakeElement.prototype.attachShadow as unknown as {
+        __rrweb_original__?: unknown;
+      };
+      expect(patched).not.toBe(original);
+      expect(patched.__rrweb_original__).toBe(original);
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/getsentry/rrweb/issues/321

For a cross-origin iframe, `contentWindow` does not throw — the browser returns a truthy restricted proxy. So the `!iframeWindow` guard in `observeAttachShadow` passes, and the bare `iframeWindow.Element` read is the first real cross-origin access. It throws a `SecurityError`, or yields `undefined` and `patchAttachShadow` then throws a `TypeError` on `element.prototype`. Both escape into the host page's `window.onerror`.

Fixed by reading `Element` inside try/catch and bailing out when it is
unreachable, since replay cannot observe a frame the browser blocks.


